### PR TITLE
Feature(#99): eslint-import-resolver-alias 라이브러리 설치

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
   ],
   ignorePatterns: ["dist", ".eslintrc.cjs"],
   parser: "@typescript-eslint/parser",
-  plugins: ["react-refresh"],
+  plugins: ["react-refresh", "import-resolver-alias"],
   rules: {
     "react/jsx-filename-extension": ["warn", { extensions: [".tsx"] }],
     "react/react-in-jsx-scope": "off",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "eslint": "^8.45.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^9.0.0",
+        "eslint-import-resolver-alias": "^1.1.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
         "postcss": "^8.4.31",
@@ -2242,6 +2243,18 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-alias": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz",
+      "integrity": "sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": ">=1.4.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "eslint": "^8.45.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "postcss": "^8.4.31",


### PR DESCRIPTION
## 작업 개요
eslint 에러 해결 close #99

## 작업 사항
- eslint 에러 발생 `Unable to resolve path to module '/vite.svg'.eslint [import/no-unresolved](https://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-unresolved.md)` 에러

- `Do not import modules using an absolute patheslint[import/no-absolute-path](https://github.com/import-js/eslint-plugin-import/blob/v2.29.0/docs/rules/no-absolute-path.md)` 에러

eslint-import-resolver-alias 설치 및 .eslintrc.cjs 수정으로 해결

## 고민한 점들(필수 X)

## 스크린샷(필수 X)
