### PR TITLE
Feature(#62): Header 컴포넌트 navigate 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import "./global.css";
 import Home from "@/pages/Home/Home";
 import Login from "./pages/Login/Login";
 import Test from "./pages/Test/Test";
+import MyPage from "./pages/MyPage/MyPage";
 
 const App = () => {
   return (
@@ -11,6 +12,7 @@ const App = () => {
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
         <Route path="/test" element={<Test />} />
+        <Route path="/mypage" element={<MyPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/components/Header/components/LeftSection.tsx
+++ b/frontend/src/components/Header/components/LeftSection.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import logoSmall from "@/assets/imgs/logoSmall.png";
 
 interface LeftSectionProps {
@@ -5,9 +6,15 @@ interface LeftSectionProps {
 }
 
 const LeftSection = ({ lecture }: LeftSectionProps) => {
+  const navigate = useNavigate();
+
+  const moveToMainPage = () => {
+    navigate("/");
+  };
+
   return (
     <div className="flex items-center gap-4 semibold-20">
-      <button type="button" className="flex flex-row items-center gap-4">
+      <button type="button" className="flex flex-row items-center gap-4" onClick={moveToMainPage}>
         <img src={logoSmall} />
         {!lecture && <h1>Boarlog</h1>}
       </button>

--- a/frontend/src/components/Header/components/ProfileModal.tsx
+++ b/frontend/src/components/Header/components/ProfileModal.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import ProfileSmall from "@/assets/imgs/profileSmall.png";
 import LogoutIcon from "@/assets/svgs/logout.svg?react";
 import UserIcon from "@/assets/svgs/user.svg?react";
@@ -8,6 +9,12 @@ interface ProfileModalProps {
 }
 
 const ProfileModal = ({ profileClicked, setProfileClicked }: ProfileModalProps) => {
+  const navigate = useNavigate();
+
+  const moveToMyPage = () => {
+    navigate("/mypage");
+  };
+
   const handleBackgroundClick = () => {
     setProfileClicked(!profileClicked);
   };
@@ -43,6 +50,7 @@ const ProfileModal = ({ profileClicked, setProfileClicked }: ProfileModalProps) 
           <button
             className="flex flex-row flex-grow justify-center items-center gap-1 py-3 rounded-xl bg-grayscale-black semibold-18 text-grayscale-white hover:bg-grayscale-darkgray duration-500"
             type="button"
+            onClick={moveToMyPage}
           >
             <UserIcon className="fill-grayscale-white" />
             마이페이지

--- a/frontend/src/pages/MyPage/MyPage.tsx
+++ b/frontend/src/pages/MyPage/MyPage.tsx
@@ -1,0 +1,12 @@
+import Header from "@/components/Header/Header";
+
+const MyPage = () => {
+  return (
+    <>
+      <Header main />
+      마이 페이지
+    </>
+  );
+};
+
+export default MyPage;


### PR DESCRIPTION
## 작업 개요
Header 컴포넌트 navigate 추가 #62 

## 작업 사항
- 로고 클릭 시에 Main으로 이동하도록 onClick 이벤트 추가
- 마이페이지로 이동 확인을 위해 마이페이지 파일 추가
- 사용자 정보 모달에서 '마이페이지' 버튼 클릭 시에 onClick 이벤트 추가

## 고민한 점들(필수 X)
~~없음~~

## 스크린샷(필수 X)

https://github.com/boostcampwm2023/web13_Boarlog/assets/79556112/3cabbe3d-b5ee-405a-9fa2-313c80c34838


