### PR TITLE
Feature(#46): ‘메모지’버튼을 누른 후 사용자가 클릭한 위치에 메모지가 생성 기능 구현

### DIFF
--- a/frontend/src/assets/svgs/addStickyMemoCursor.svg
+++ b/frontend/src/assets/svgs/addStickyMemoCursor.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M22 4C22 2.9 21.1 2 20 2H4C2.9 2 2 2.9 2 4V16C2 17.1 2.9 18 4 18H18L22 22V4ZM20 17.17L18.83 16H4V4H20V17.17ZM13 5H11V9H7V11H11V15H13V11H17V9H13V5Z" fill="black"/>
+<path d="M1 1V7L7 1H1Z" fill="black" stroke="black"/>
+</svg>

--- a/frontend/src/pages/Test/components/Toolbar.tsx
+++ b/frontend/src/pages/Test/components/Toolbar.tsx
@@ -65,7 +65,7 @@ const Toolbar = () => {
 
         canvas.on("mouse:down", ({ absolutePointer }: fabric.IEvent<MouseEvent>) => {
           if (!absolutePointer) return;
-          const { x: mousePositionX, y: mousePositionY, ...rest } = absolutePointer;
+          const [mousePositionX, mousePositionY] = [absolutePointer.x, absolutePointer.y];
 
           const rect = new fabric.Rect({
             left: mousePositionX,


### PR DESCRIPTION
## 작업 개요

‘메모지’버튼을 누른 후 사용자가 클릭한 위치에 메모지가 생성 기능 구현 close #46 

## 작업 사항

- [x] 메모지 버튼을 누른후 클릭한 위치에 메모지가 생성된다.
- [x] 메모지 생성 후 모드를 바꾼다.(일단은 선택 모드)
- [x] 기존 메모지가 생성되어 있는 위치에서 새 메모지를 생성시 기존 메모지가 선택되던 버그 해결
- [x] 추가: 메모 버튼을 클릭시 커서를 변경해 UI에 사용자가 메모 버튼이 눌려있음을 확인할 수 있게 한다.

## 고민한 점들(필수 X)

### 기존 메모지가 생성되어 있는 위치에서 새 메모지를 생성시 기존 메모지가 선택되던 버그 해결

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/aeb24cd0-be6c-410a-ac2b-911b1bd02bc8


#### 원인

canvas의 object들의 selectable 옵션이 true로 지정되어있어, 메모 생성을 위한 클릭 시 기존 메모를 선택하기 때문입니다.

#### 해결

select 툴을 선택했을 때만 그래픽 요소들을 선택(클릭, 드래그 블록지정)할 수 있도록 useEffect의 콜백이 실행시 캔버스 옵션을 리셋(initCanvasOption함수)하도록 했습니다. 
+ 커서를 디폴트 포인터로 리셋하도록 바꿔 마우스 커서가 툴에 맞게 표시될 수 있도록 수정했습니다.
+ 드로잉 모드를 끄도록 수정했습니다.

```
 /**
   * @description 화이트 보드에 그려져 있는 요소들을 클릭을 통해 선택 가능한지 여부를 제어하기 위한 함수입니다.
   */
  const setIsObjectSelectable = (isSelectable: boolean) => {
    if (!(canvas instanceof fabric.Canvas)) return;
    canvas.forEachObject((o) => (o.selectable = isSelectable));
  };

  /**
   * @description 캔버스의 옵션을 리셋하는 함수입니다.
   * @description 그래픽 요소 선택 기능: off, 드로잉 모드: off, 드래그 블럭지정모드: off, 커서: 디폴트 포인터
   */
  const initCanvasOption = () => {
    if (!(canvas instanceof fabric.Canvas)) return;
    setIsObjectSelectable(false);
    canvas.isDrawingMode = false;
    canvas.selection = false;
    canvas.defaultCursor = "default";
  };
```

## 스크린샷(필수 X)

### 메모 추가 기능

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/acb73723-347a-49cc-8005-4047879dc573


### 메모 추가 툴 선택이 되어있을 때, 마우스 커서 변경

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/12142e3f-32bb-49f4-bfa9-ed505d870dc0



