### PR TITLE
Fix(#142): 캔버스 클릭 후 메모 클릭시 글꼴 초기화 되는 문제 해결

### DIFF
--- a/frontend/src/pages/Test/components/StickyNoteEditPanel.tsx
+++ b/frontend/src/pages/Test/components/StickyNoteEditPanel.tsx
@@ -12,7 +12,6 @@ import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 
 import StickyNoteColorPanel from "./StickyNoteColorPanel";
-
 import stickyNoteInstance from "./stateStickyNoteInstance";
 import cavasInstanceState from "./stateCanvasInstance";
 
@@ -49,11 +48,24 @@ const getFontSizePixelByCode = (code: FontSize): FontSizePixel => {
 };
 
 const StickyNoteEditPanel = () => {
-  const [isPalletteActive, setIsPalletteActive] = useState(false);
-  const [fontSize, setFontSize] = useState<FontSize>("m");
-  const [formatAlign, setFormatAlign] = useState<FormatAlign>("left");
   const noteInstance = useRecoilValue(stickyNoteInstance);
   const canvas = useRecoilValue(cavasInstanceState);
+
+  const getClickedMemoData = (noteInstance: fabric.Object): { align: FormatAlign; fontSize: FontSize } => {
+    // @ts-ignore
+    const textBox = noteInstance.item(1);
+
+    const align = textBox.get("textAlign");
+    const fontSize = getFontSizeByPixel(textBox.get("fontSize"));
+
+    if (!align || !fontSize) return { align: "left", fontSize: "m" };
+
+    return { align: align, fontSize: fontSize };
+  };
+
+  const [isPalletteActive, setIsPalletteActive] = useState(false);
+  const [fontSize, setFontSize] = useState<FontSize>(getClickedMemoData(noteInstance).fontSize);
+  const [formatAlign, setFormatAlign] = useState<FormatAlign>(getClickedMemoData(noteInstance).align);
 
   const handlePalletteButtonClick = () => {
     setIsPalletteActive(!isPalletteActive);
@@ -64,24 +76,18 @@ const StickyNoteEditPanel = () => {
   };
 
   const handleFormatAlignButtonClick = (align: FormatAlign) => {
-    if (!noteInstance || !canvas) return;
-
-    // @ts-ignore
-    const textBox = noteInstance.item(1);
     setFormatAlign(align);
   };
 
   const handleDeleteNote = () => {
     if (!noteInstance || !canvas) return;
 
-    // @ts-ignore
     canvas.remove(noteInstance);
     canvas.renderAll();
   };
 
   useEffect(() => {
     if (!noteInstance || !canvas) return;
-
     // @ts-ignore
     const textBox = noteInstance.item(1);
 
@@ -102,19 +108,14 @@ const StickyNoteEditPanel = () => {
   }, [formatAlign]);
 
   useEffect(() => {
-    if (!noteInstance) return;
+    const { align: textAlign, fontSize: textFontSize } = getClickedMemoData(noteInstance);
 
-    // @ts-ignore
-    const textBox = noteInstance.item(1);
-    const textAlign: FormatAlign = textBox.get("textAlign");
-    const textFontSize = textBox.get("fontSize");
-
-    setFontSize(getFontSizeByPixel(textFontSize));
+    setFontSize(textFontSize);
     setFormatAlign(textAlign);
   }, [noteInstance]);
 
   return (
-    <div className="absolute top-2.5 left-1/2 translate-x-[-50%] ">
+    <div className="absolute top-2.5 left-1/2 -translate-x-1/2 ">
       <div className="w-[22.25rem] h-[2.875rem] px-4 bg-grayscale-lightgray rounded-xl flex items-center relative shadow-md">
         {isPalletteActive && <StickyNoteColorPanel />}
         <div className="flex items-center gap-3 after:content-[''] after:block after:w-px after:h-[20px] after:bg-grayscale-gray">

--- a/frontend/src/pages/Test/components/stateStickyNoteInstance.ts
+++ b/frontend/src/pages/Test/components/stateStickyNoteInstance.ts
@@ -1,6 +1,6 @@
 import { atom } from "recoil";
 
-const stickyNoteInstance = atom<Object>({
+const stickyNoteInstance = atom<fabric.Object>({
   key: "stickyNoteInstance",
   default: undefined,
   dangerouslyAllowMutability: true


### PR DESCRIPTION
## 작업 개요
캔버스 클릭 후 메모 클릭시 글꼴 초기화 되는 문제 해결 close #142 

## 작업 사항
- 원인: StickyNoteEditPanel 컴포넌트가 랜더링되어 있지 않다가 StickyNoteEditPanel 컴포넌트 랜더링시 useState의 초기 값을 m, left로 재 설정하기 때문에 메모지의 상태가 리셋이 되는 문제가 발생했습니다.
  ```
    // StickyNoteEditPanel.tsx 중
    const [fontSize, setFontSize] = useState<FontSize>("m");
    const [formatAlign, setFormatAlign] = useState<FormatAlign>("left");
  ```

- 해결: useState의 초기 값을 선택된 메모의 데이터(폰트 사이즈, 정렬)를 getClickedMemoData함수를 통해 가져와 맵핑

## 고민한 점들(필수 X)


## 스크린샷(필수 X)

### 해결 전

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/c847e3ca-bc79-4c0e-9507-24de0760aa5b


### 해결 후

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/fc8c9e7d-9b2d-48af-aee6-5d62d88560d4

