### PR TITLE
Fix(#149) 배포환경에서 MediaStream 참여자가 못 받는 문제 수정

### DIFF
--- a/mediaServer/package-lock.json
+++ b/mediaServer/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "socket.io": "^4.7.2",
         "wrtc": "^0.4.7"
@@ -2714,6 +2715,17 @@
       "optional": true,
       "dependencies": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/ee-first": {

--- a/mediaServer/package.json
+++ b/mediaServer/package.json
@@ -46,6 +46,7 @@
     "testEnvironment": "node"
   },
   "dependencies": {
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "socket.io": "^4.7.2",
     "wrtc": "^0.4.7"

--- a/mediaServer/src/RelayServer.ts
+++ b/mediaServer/src/RelayServer.ts
@@ -1,5 +1,6 @@
 import { Server, Socket } from 'socket.io';
 import { RTCIceCandidate, RTCPeerConnection } from 'wrtc';
+import dotenv from 'dotenv';
 
 export class RelayServer {
   private readonly io;
@@ -25,7 +26,20 @@ export class RelayServer {
   createRoom = (socket: Socket) => {
     try {
       socket.on('presenterOffer', async (data) => {
-        const RTCPC = new RTCPeerConnection();
+        dotenv.config();
+        const pc_config = {
+          iceServers: [
+            {
+              urls: ['stun:stun.l.google.com:19302']
+            },
+            {
+              urls: process.env.TURN_URL as string,
+              username: process.env.TURN_USERNAME as string,
+              credential: process.env.TURN_PASSWORD as string
+            }
+          ]
+        };
+        const RTCPC = new RTCPeerConnection(pc_config);
         this.relayServerRTCPC = RTCPC;
 
         RTCPC.ontrack = (event) => {

--- a/mediaServer/src/main.ts
+++ b/mediaServer/src/main.ts
@@ -1,7 +1,22 @@
 import { RelayServer } from './RelayServer';
+import * as http from 'http';
+import fs from 'fs';
 
 const PORT = 3000;
 
 const relayServer = new RelayServer(PORT);
 relayServer.listen('/create-room', 'connection', relayServer.createRoom);
 relayServer.listen('/enter-room', 'connection', relayServer.enterRoom);
+
+const app = http.createServer((req, res) => {
+  try {
+    fs.readFile(__dirname + '/../' + req.url, (err, file) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(file);
+    });
+  } catch (e) {
+    console.log(e);
+  }
+});
+
+app.listen(8080);

--- a/mediaServer/test/presenter/index.html
+++ b/mediaServer/test/presenter/index.html
@@ -17,9 +17,9 @@
     <button id="hangupButton">방 나가기</button>
   </div>
 </div>
+<script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
 <script type="module">
-  import { io } from "https://cdn.socket.io/4.4.1/socket.io.esm.min.js";
-  const socket = io('http://localhost:3000/create-room');
+  const socket = io('http://110.165.16.37:3000/create-room');
 
   const startButton = document.getElementById('startButton');
   const callButton = document.getElementById('callButton');
@@ -40,6 +40,12 @@
           "stun:stun.l.google.com:19302",
         ]
       },
+      {
+        urls: "",
+	      username: "",
+	      credential: "",
+
+      }
     ],
   };
 
@@ -53,7 +59,7 @@
       localStream = stream;
       localVideo.srcObject = stream;
       callButton.disabled = false;
-      presenterRTCPC = new RTCPeerConnection();
+      presenterRTCPC = new RTCPeerConnection(pc_config);
     
       if (localStream) {
         localStream.getTracks().forEach((track) => { 

--- a/mediaServer/test/student/index.html
+++ b/mediaServer/test/student/index.html
@@ -9,17 +9,16 @@
 <body>
 <div id="container">
   <h1>참여자</h1>
-  <video id="localVideo" playsinline autoplay muted></video>
-  <canvas></canvas>
+  <video id="localVideo" playsinline autoplay muted height="500px" width="500px"></video>
   <div>
     <button id="startButton">시작</button>
     <button id="callButton">방 생성</button>
     <button id="hangupButton">방 나가기</button>
   </div>
 </div>
+<script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
 <script type="module">
-  import { io } from "https://cdn.socket.io/4.4.1/socket.io.esm.min.js";
-  const socket = io('http://localhost:3000/enter-room');
+  const socket = io('http://110.165.16.37:3000/enter-room');
 
   const startButton = document.getElementById('startButton');
   const callButton = document.getElementById('callButton');
@@ -40,23 +39,35 @@
           "stun:stun.l.google.com:19302",
         ]
       },
+      {
+        urls: "",
+        username: "",
+        credential: "",
+
+      }
     ],
   };
 
   const start = async () => {
     try {
-      presenterRTCPC = new RTCPeerConnection();
-      const stream = new MediaStream();
-      localStream = stream;
+      localVideo.srcObject = localStream;
+      localVideo.addEventListener('loadedmetadata', () => {
+        localVideo.play();
+      })
     } catch (e) {
       console.log(e)
     }
   }
 
-  start().then(getStream)
+  //start().then(getStream)
+  getStream().then(start);
 
   async function getStream() {
     try {
+      presenterRTCPC = new RTCPeerConnection(pc_config);
+      const stream = new MediaStream();
+      localStream = stream;
+
       await createStudentOffer();
       await setServerAnswer();
     } catch (e) {
@@ -103,8 +114,7 @@
   }
 
   presenterRTCPC.ontrack = (event) => {
-    localStream.addTrack(event.track)
-    localVideo.srcObject = localStream;
+    localStream.addTrack(event.track);
   }
 
   startButton.onclick = start;


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
close #149 `배포 환경에서 사용자들끼리 webRTC를 연결하고 MediaStream을 주고 받는다.`

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
로컬에서는 잘 되는데 배포환경에서 접속했을 때 webRTC 연결이 제대로 되지 않는 문제를 해결했습니다.
서로 connection 연결할 때 turn 서버를 설정해줘서 연결이 잘 되도록 수정했습니다.
배포 서버에서 turn 서버 구축을 해주어서 코드 상 변화는 크게 없습니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
test용 html 파일에서 `pc_config` 안에 turn 서버 url이나 username, password를 적어줘야 하는데 html 파일 안에 값을 바로 적으면 값들이 노출되기 때문에 다른 방법을 찾아보았습니다. `RelayServer.ts`에서는 환경변수를 활용해서 `process.env.변수이름`으로 호출하는 방법을 선택했는데 html 파일 내에서는 환경변수를 사용할 수 없어서 고민이 되었습니다. 해당 파일은 테스트용 html 파일이고 실제 프론트엔드와 합치게 되면 React 내에서 환경변수를 써서 동적으로 바꿔주는 게 가능하기 때문에, 테스트용 html은 해당 내용을 비워두기로 결정했습니다. 배포환경에서 테스트할 시에 html 내의 값들을 채워주고 테스트해주면 됩니다.
