### PR TITLE
Fix(#168): 화면 배율에 따라 질문 리스트의 높이와 그 컨테이너의 높이 차이 해결 

### DIFF
--- a/frontend/src/pages/Test/components/QuestionButton.tsx
+++ b/frontend/src/pages/Test/components/QuestionButton.tsx
@@ -5,9 +5,12 @@ import activeToolState from "./stateActiveTool";
 
 const IndicatorBubble = ({ count }: { count: number }) => {
   return (
-    <div className="absolute -top-2 -right-2 flex justify-center items-center rounded-xl w-5 h-5  bg-alert-100 medium-12 text-grayscale-white">
-      {count}
-    </div>
+    <>
+      <div className="animate-ping absolute -top-2 -right-2 rounded-xl w-5 h-5  bg-alert-100"></div>
+      <div className="absolute -top-2 -right-2 flex justify-center items-center rounded-xl w-5 h-5  bg-alert-100 medium-12 text-grayscale-white">
+        {count}
+      </div>
+    </>
   );
 };
 

--- a/frontend/src/pages/Test/components/QuestionList.tsx
+++ b/frontend/src/pages/Test/components/QuestionList.tsx
@@ -60,7 +60,7 @@ const QuestionList = () => {
   }, []);
 
   return (
-    <section className="w-60 h-[80vh] border border-default rounded-xl absolute top-2.5 left-20 mb-6 bg-grayscale-white">
+    <section className="w-60 h-[41rem] border border-default rounded-xl absolute top-2.5 left-20 mb-6 bg-grayscale-white">
       <h2 className="semibold-18 inline-block mt-1 p-4">질문 리스트</h2>
       <div className="h-[36rem] px-4 overflow-scroll">
         <ul ref={listRef}>


### PR DESCRIPTION
## 작업 사항

배율을 조절함에 따라 질문 리스트와 질문리스트 래퍼의 크기 차이가 생기는 문제 해결 close #168 

## 고민한 점들(필수 X)

컨테이너(vh)와 리스트(rem)의 단위의 차이 때문에 생기는 문제 -> 컨테이너의 vh 단위를 rem단위로 설정

## 스크린샷(필수 X)

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/7dc0b8e8-9dba-4f62-85f2-060f81f194d9


## 추가 사항

- 추가: QuestionButton에 핑 애니메이션 추가