### PR TITLE
Fix(#177, #178): 화이트보드(지우개, 메모지) 관련 버그 수정

### DIFF
--- a/frontend/src/pages/Test/components/Toolbar.tsx
+++ b/frontend/src/pages/Test/components/Toolbar.tsx
@@ -102,10 +102,11 @@ const Toolbar = () => {
         prevTextBox: fabric.Textbox,
         memoGroup: fabricObjectWithAddWithUpdate
       ) => {
-        let newTextContents = dummyTextBox.text?.replace(/\n/g, "");
+        let newTextContents = dummyTextBox.text;
 
         // 만약 텍스트 박스를 비운채로 편집을 마쳤다면 메모의 내용을 다시 디폴트 상태로 돌려줍니다.
-        if (newTextContents?.length === 0) newTextContents = "더블 클릭해 메모 내용을 편집하세요...";
+        if (dummyTextBox.text?.replace(/\n|\s/g, "")?.length === 0)
+          newTextContents = "더블 클릭해 메모 내용을 편집하세요...";
 
         // 더미 텍스트를 보여주기 전 숨겼던 텍스트 박스를 보여주고 새로운 내용으로 텍스트를 갱신합니다.
         prevTextBox.set({

--- a/frontend/src/pages/Test/components/Toolbar.tsx
+++ b/frontend/src/pages/Test/components/Toolbar.tsx
@@ -206,17 +206,21 @@ const Toolbar = () => {
 
     canvas.defaultCursor = `url("${EraserCursor}"), auto`;
 
-    canvas.on("mouse:up", ({ target }) => {
+    const handleMouseUp = (target: fabric.Object | undefined) => {
       if (!target) return;
       canvas.remove(target);
-    });
+    };
 
-    canvas.on("selection:created", ({ selected }) => {
+    const handleSelectionCreated = (selected: fabric.Object[] | undefined) => {
       if (activeTool === "eraser") {
         selected?.forEach((object) => canvas.remove(object));
       }
       canvas.discardActiveObject().renderAll();
-    });
+    };
+
+    canvas.on("mouse:up", ({ target }) => handleMouseUp(target));
+
+    canvas.on("selection:created", ({ selected }) => handleSelectionCreated(selected));
   };
 
   const handleHand = () => {
@@ -247,6 +251,7 @@ const Toolbar = () => {
     canvas.off("mouse:down");
     canvas.off("mouse:move");
     canvas.off("mouse:up");
+    canvas.off("selection:created");
 
     resetCanvasOption();
 


### PR DESCRIPTION
## 작업 개요
화이트보드(지우개, 메모지) 관련 버그 수정

## 작업 사항

fix: 지우개 툴 선택 후 선택툴 클릭시 요소 삭제 오류 해결 close #177
fix: 메모지 내에 입력한 개행이 사라지는 버그 close #178

## 고민한 점들(필수 X)

### fix: 지우개 툴 선택 후 선택툴 클릭시 요소 삭제 오류 해결

- 원인: 지우개의 selection:created 이벤트가 등록된 상태로 선택 툴에서 같은 이벤트가 발생해 그래픽 요소 삭제

- 해결: 툴이 바뀔 때마다 이벤트를 지워주는 코드가 있는데 selection:created도 지우도록 했습니다.

### fix: 메모지 내에 입력한 개행이 사라지는 버그

- 원인: 메모지에 공백을 입력시 텍스트를 디폴트 값으로 바꿔주게 구현이 되어있습니다.
개행만 하고 다른 텍스트를 입력하지 않았을 때를 체크하기 위해 모든 개행문자를 제거하고 글자 수를 체크합니다.
이 개행문자가 제거된 텍스트가 편집후 메모지의 텍스트 내용으로 갱신되기 때문에 문제가 발생했습니다.

- 해결: 개행만하고 다른 문자를 입력하지 않는가를 체크하기 위해 개행을 제거하는 동작을 조건문 안에서만 실행되게 수정했습니다.

- 추가 사항: 개행 뿐만 아니라 띄어쓰기로만 이뤄진 텍스트인가도 체크하도록 정규표현식을 수정했습니다.

## 스크린샷(필수 X)

- 삭제 버그 해결

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/ad232131-82f8-4bbc-a4de-3bb24ae4ebe9

- 개행 제거 버그 해결

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/cbb396da-54bd-4717-a371-69cda4c7fc73

