### PR TITLE
Fix(#183) 강의 참여시 곧바로 발표자의 화이트보드가 보이도록 개선

### DIFF
--- a/frontend/src/components/Header/components/HeaderInstructorControls.tsx
+++ b/frontend/src/components/Header/components/HeaderInstructorControls.tsx
@@ -34,8 +34,6 @@ const HeaderInstructorControls = () => {
   const canvasRef = useRecoilValue(canvasRefState);
   const fabricCanvasRef = useRecoilValue(cavasInstanceState);
 
-  const localVideoRef = useRef<HTMLVideoElement>(null);
-
   const timerIdRef = useRef<number | null>(null); // 경과 시간 표시 타이머 id
   const onFrameIdRef = useRef<number | null>(null); // 마이크 볼륨 측정 타이머 id
   const socketRef = useRef<Socket>();
@@ -44,8 +42,7 @@ const HeaderInstructorControls = () => {
   const updatedStreamRef = useRef<MediaStream>();
   const inputMicVolumeRef = useRef<number>(0);
   const prevInputMicVolumeRef = useRef<number>(0);
-  const MEDIA_SERVER_URL = "http://localhost:3000";
-  //const MEDIA_SERVER_URL = "https://www.boarlog.site";
+  const MEDIA_SERVER_URL = "https://www.boarlog.site";
   const pc_config = {
     iceServers: [
       {
@@ -121,15 +118,12 @@ const HeaderInstructorControls = () => {
 
       // canvas의 내용을 캡쳐하여 스트림으로 생성
       if (!canvasRef.current) return;
-      const canvasStream = canvasRef.current.captureStream(30);
+      const canvasStream = canvasRef.current.captureStream();
 
       // canvas 스트림의 track을 updatedStream에 추가
       canvasStream.getTracks().forEach((track) => {
         if (!updatedStreamRef.current) return;
         updatedStreamRef.current.addTrack(track);
-
-        const frameRate = track.getSettings();
-        console.log("getSettings:", track.getSettings());
       });
 
       // RTCPeerConnection 생성
@@ -145,9 +139,6 @@ const HeaderInstructorControls = () => {
       } else {
         console.error("no stream");
       }
-
-      if (!localVideoRef.current || !updatedStreamRef.current) return;
-      localVideoRef.current.srcObject = updatedStreamRef.current;
 
       // RTCPeerConnection에 추가된 트랙 확인 (디버깅용)
       const senders = pcRef.current.getSenders();
@@ -306,7 +297,7 @@ const HeaderInstructorControls = () => {
   // JSON 형태로 화이트보드를 공유하기 위한 테스트 코드입니다.
   // 배포 페이지에는 포함되면 안될 것 같아 임시로 주석처리합니다.
   // socket으로 데이터 주고받기가 가능해지면 다시 살려서 구현하겠습니다.
-
+  /*
   interface ICanvasData {
     canvasJSON: string;
     viewport: number[];
@@ -329,7 +320,6 @@ const HeaderInstructorControls = () => {
     if (instructorCanvasData.canvasJSON !== newJSONData || instructorCanvasData.viewport !== newViewport) {
       instructorCanvasData.canvasJSON = newJSONData;
       instructorCanvasData.viewport = newViewport;
-      //console.log(instructorCanvasData.canvasJSON);
     }
   }
 
@@ -337,21 +327,15 @@ const HeaderInstructorControls = () => {
     saveCanvasData();
     //onFrameIdRef2.current = window.requestAnimationFrame(saveCanvasData);
   };
-  const cancle = () => {
+  const cancel = () => {
     if (!onFrameIdRef2.current) return;
     window.cancelAnimationFrame(onFrameIdRef2.current);
   };
   const load = () => {
     if (!fabricCanvasRef) return;
-    console.log("------------------");
-
-    fabricCanvasRef.loadFromJSON(instructorCanvasDataRef.current.canvasJSON, () => {
-      console.log("JSON 데이터 로드 완료");
-      //fabricCanvasRef.renderAll();
-    });
+    fabricCanvasRef.loadFromJSON(instructorCanvasDataRef.current.canvasJSON, () => {});
     fabricCanvasRef.setViewportTransform(instructorCanvasDataRef.current.viewport);
 
-    /*
     //lectureSocketRef.current = io(`${MEDIA_SERVER_URL}`);
     if (!socketRef.current) return;
     socketRef.current.emit("edit", {
@@ -359,42 +343,8 @@ const HeaderInstructorControls = () => {
       roomId: 1,
       content: "test"
     });
-
-    socketRef.current.emit("edit", {
-      type: "whiteBoard",
-      roomId: 1,
-      content: "test"
-    });
-    */
   };
-  const sendtest = () => {
-    if (!updatedStreamRef.current) return;
-    //console.log(updatedStreamRef.current.getVideoTracks()[0]);
-    //updatedStreamRef.current.getVideoTracks()[0].requestFrame();
-
-    /*
-    var rect = new fabric.Rect({
-      left: 200,
-      top: 200,
-      fill: "red",
-      width: 20,
-      height: 20
-    });
-
-    if (!fabricCanvasRef) return;
-    fabricCanvasRef.add(rect);
-    */
-
-    function createAndRemoveRect() {
-      if (!fabricCanvasRef) return;
-      fabricCanvasRef.renderAll();
-    }
-    setInterval(createAndRemoveRect, 100);
-
-    //fabricCanvasRef.renderAll();
-
-    console.log("sendtest");
-  };
+  */
 
   return (
     <>
@@ -431,15 +381,6 @@ const HeaderInstructorControls = () => {
           <MicOffIcon className="w-5 h-5 fill-grayscale-white" />
         )}
       </SmallButton>
-      <SmallButton className={`text-grayscale-white bg-boarlog-100`} onClick={save}>
-        1
-      </SmallButton>
-      <SmallButton className={`text-grayscale-white bg-boarlog-100`} onClick={cancle}>
-        2
-      </SmallButton>
-      <SmallButton className={`text-grayscale-white bg-boarlog-100`} onClick={sendtest}>
-        3
-      </SmallButton>
       <Modal
         modalText="강의를 시작하시겠습니까?"
         cancelText="취소"
@@ -460,7 +401,6 @@ const HeaderInstructorControls = () => {
         isModalOpen={isCloseModalOpen}
         setIsModalOpen={setIsCloseModalOpen}
       />
-      <video id="localVideo" controls autoPlay height="500px" width="500px" ref={localVideoRef} hidden></video>
     </>
   );
 };

--- a/frontend/src/components/Header/components/HeaderInstructorControls.tsx
+++ b/frontend/src/components/Header/components/HeaderInstructorControls.tsx
@@ -15,7 +15,7 @@ import { useToast } from "@/components/Toast/useToast";
 import selectedMicrophoneState from "./stateSelectedMicrophone";
 import micVolmeState from "./stateMicVolme";
 import canvasRefState from "@/pages/Test/components/stateCanvasRef";
-//import cavasInstanceState from "@/pages/Test/components/stateCanvasInstance";
+import cavasInstanceState from "@/pages/Test/components/stateCanvasInstance";
 
 const HeaderInstructorControls = () => {
   const [isLectureStart, setIsLectureStart] = useState(false);
@@ -31,7 +31,7 @@ const HeaderInstructorControls = () => {
   const showToast = useToast();
 
   const canvasRef = useRecoilValue(canvasRefState);
-  //const fabricCanvasRef = useRecoilValue(cavasInstanceState);
+  const fabricCanvasRef = useRecoilValue(cavasInstanceState);
 
   const timerIdRef = useRef<number | null>(null); // 경과 시간 표시 타이머 id
   const onFrameIdRef = useRef<number | null>(null); // 마이크 볼륨 측정 타이머 id
@@ -41,7 +41,8 @@ const HeaderInstructorControls = () => {
   const updatedStreamRef = useRef<MediaStream>();
   const inputMicVolumeRef = useRef<number>(0);
   const prevInputMicVolumeRef = useRef<number>(0);
-  const MEDIA_SERVER_URL = "https://www.boarlog.site";
+  const MEDIA_SERVER_URL = "http://localhost:3000";
+  //const MEDIA_SERVER_URL = "https://www.boarlog.site";
   const pc_config = {
     iceServers: [
       {
@@ -286,20 +287,21 @@ const HeaderInstructorControls = () => {
   // JSON 형태로 화이트보드를 공유하기 위한 테스트 코드입니다.
   // 배포 페이지에는 포함되면 안될 것 같아 임시로 주석처리합니다.
   // socket으로 데이터 주고받기가 가능해지면 다시 살려서 구현하겠습니다.
-  /*
+
   let saveJSON: any = null;
   const save = () => {
     if (!fabricCanvasRef) return;
     saveJSON = JSON.stringify(fabricCanvasRef);
     console.log(saveJSON);
   };
-  const load = () => {    
+  const load = () => {
     if (!fabricCanvasRef) return;
-    fabricCanvasRef.loadFromJSON(test, () => {
+    fabricCanvasRef.loadFromJSON(saveJSON, () => {
       console.log("JSON 데이터 로드 완료");
       fabricCanvasRef.renderAll();
     });
-    
+
+    /*
     //lectureSocketRef.current = io(`${MEDIA_SERVER_URL}`);
     if (!socketRef.current) return;
     socketRef.current.emit("edit", {
@@ -313,8 +315,8 @@ const HeaderInstructorControls = () => {
       roomId: 1,
       content: "test"
     });
+    */
   };
-  */
 
   return (
     <>
@@ -350,6 +352,12 @@ const HeaderInstructorControls = () => {
         ) : (
           <MicOffIcon className="w-5 h-5 fill-grayscale-white" />
         )}
+      </SmallButton>
+      <SmallButton className={`text-grayscale-white bg-boarlog-100`} onClick={save}>
+        저장
+      </SmallButton>
+      <SmallButton className={`text-grayscale-white bg-boarlog-100`} onClick={load}>
+        불러오기
       </SmallButton>
       <Modal
         modalText="강의를 시작하시겠습니까?"

--- a/frontend/src/components/Header/components/HeaderInstructorControls.tsx
+++ b/frontend/src/components/Header/components/HeaderInstructorControls.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { io, Socket } from "socket.io-client";
-import { fabric } from "fabric";
 
 import VolumeMeter from "./VolumeMeter";
 

--- a/frontend/src/components/Header/components/HeaderInstructorControls.tsx
+++ b/frontend/src/components/Header/components/HeaderInstructorControls.tsx
@@ -288,23 +288,35 @@ const HeaderInstructorControls = () => {
   // 배포 페이지에는 포함되면 안될 것 같아 임시로 주석처리합니다.
   // socket으로 데이터 주고받기가 가능해지면 다시 살려서 구현하겠습니다.
 
-  let saveJSON: any = null;
+  interface ICanvasData {
+    canvasJSON: string;
+    viewport: number[];
+  }
+  let instructorCanvasData: ICanvasData = {
+    canvasJSON: "",
+    viewport: [1, 0, 0, 1, 0, 0]
+  };
+  let instructorCanvasDataRef = useRef<ICanvasData>(instructorCanvasData);
+  instructorCanvasDataRef.current = instructorCanvasData;
+
   const onFrameIdRef2 = useRef<number | null>(null); // 마이크 볼륨 측정 타이머 id
 
   function saveCanvasData() {
+    if (!fabricCanvasRef || !fabricCanvasRef.viewportTransform) return;
+
     const newJSONData = JSON.stringify(fabricCanvasRef);
-    if (saveJSON !== newJSONData) {
-      saveJSON = newJSONData;
-      console.log(saveJSON);
+    const newViewport = fabricCanvasRef.viewportTransform;
+
+    if (instructorCanvasData.canvasJSON !== newJSONData || instructorCanvasData.viewport !== newViewport) {
+      instructorCanvasData.canvasJSON = newJSONData;
+      instructorCanvasData.viewport = newViewport;
+      //console.log(instructorCanvasData.canvasJSON);
     }
-    saveJSON = newJSONData;
-    console.log(saveJSON);
-    onFrameIdRef2.current = window.requestAnimationFrame(saveCanvasData);
   }
 
-  // Start the animation loop
   const save = () => {
-    onFrameIdRef2.current = window.requestAnimationFrame(saveCanvasData);
+    saveCanvasData();
+    //onFrameIdRef2.current = window.requestAnimationFrame(saveCanvasData);
   };
   const cancle = () => {
     if (!onFrameIdRef2.current) return;
@@ -312,10 +324,13 @@ const HeaderInstructorControls = () => {
   };
   const load = () => {
     if (!fabricCanvasRef) return;
-    fabricCanvasRef.loadFromJSON(saveJSON, () => {
+    console.log("------------------");
+
+    fabricCanvasRef.loadFromJSON(instructorCanvasDataRef.current.canvasJSON, () => {
       console.log("JSON 데이터 로드 완료");
-      fabricCanvasRef.renderAll();
+      //fabricCanvasRef.renderAll();
     });
+    fabricCanvasRef.setViewportTransform(instructorCanvasDataRef.current.viewport);
 
     /*
     //lectureSocketRef.current = io(`${MEDIA_SERVER_URL}`);

--- a/frontend/src/components/Header/components/HeaderInstructorControls.tsx
+++ b/frontend/src/components/Header/components/HeaderInstructorControls.tsx
@@ -289,10 +289,26 @@ const HeaderInstructorControls = () => {
   // socket으로 데이터 주고받기가 가능해지면 다시 살려서 구현하겠습니다.
 
   let saveJSON: any = null;
-  const save = () => {
-    if (!fabricCanvasRef) return;
-    saveJSON = JSON.stringify(fabricCanvasRef);
+  const onFrameIdRef2 = useRef<number | null>(null); // 마이크 볼륨 측정 타이머 id
+
+  function saveCanvasData() {
+    const newJSONData = JSON.stringify(fabricCanvasRef);
+    if (saveJSON !== newJSONData) {
+      saveJSON = newJSONData;
+      console.log(saveJSON);
+    }
+    saveJSON = newJSONData;
     console.log(saveJSON);
+    onFrameIdRef2.current = window.requestAnimationFrame(saveCanvasData);
+  }
+
+  // Start the animation loop
+  const save = () => {
+    onFrameIdRef2.current = window.requestAnimationFrame(saveCanvasData);
+  };
+  const cancle = () => {
+    if (!onFrameIdRef2.current) return;
+    window.cancelAnimationFrame(onFrameIdRef2.current);
   };
   const load = () => {
     if (!fabricCanvasRef) return;
@@ -354,10 +370,13 @@ const HeaderInstructorControls = () => {
         )}
       </SmallButton>
       <SmallButton className={`text-grayscale-white bg-boarlog-100`} onClick={save}>
-        저장
+        1
+      </SmallButton>
+      <SmallButton className={`text-grayscale-white bg-boarlog-100`} onClick={cancle}>
+        2
       </SmallButton>
       <SmallButton className={`text-grayscale-white bg-boarlog-100`} onClick={load}>
-        불러오기
+        3
       </SmallButton>
       <Modal
         modalText="강의를 시작하시겠습니까?"

--- a/frontend/src/components/Header/components/HeaderParticipantControls.tsx
+++ b/frontend/src/components/Header/components/HeaderParticipantControls.tsx
@@ -69,6 +69,7 @@ const HeaderParticipantControls = () => {
   }, [selectedSpeaker]);
 
   const enterLecture = async () => {
+    showToast({ message: "서버에 접속하는 중입니다.", type: "default" });
     await initConnection();
 
     await createStudentOffer();
@@ -93,11 +94,11 @@ const HeaderParticipantControls = () => {
         });
         videoRef.current.addEventListener("loadedmetadata", () => {
           console.log("loadedmetadata");
+          showToast({ message: "음소거 해제 후 소리를 들을 수 있습니다.", type: "alert" });
         });
         videoRef.current.play();
       }
     };
-    showToast({ message: "음소거 해제 후 소리를 들을 수 있습니다.", type: "alert" });
   };
 
   const leaveLecture = () => {

--- a/frontend/src/components/Header/components/HeaderParticipantControls.tsx
+++ b/frontend/src/components/Header/components/HeaderParticipantControls.tsx
@@ -41,7 +41,8 @@ const HeaderParticipantControls = () => {
   const navigate = useNavigate();
   const showToast = useToast();
 
-  const MEDIA_SERVER_URL = "https://www.boarlog.site/enter-room";
+  const MEDIA_SERVER_URL = "http://localhost:3000/enter-room";
+  //const MEDIA_SERVER_URL = "https://www.boarlog.site/enter-room";
   const pc_config = {
     iceServers: [
       {

--- a/frontend/src/components/Header/components/HeaderParticipantControls.tsx
+++ b/frontend/src/components/Header/components/HeaderParticipantControls.tsx
@@ -41,8 +41,7 @@ const HeaderParticipantControls = () => {
   const navigate = useNavigate();
   const showToast = useToast();
 
-  const MEDIA_SERVER_URL = "http://localhost:3000/enter-room";
-  //const MEDIA_SERVER_URL = "https://www.boarlog.site/enter-room";
+  const MEDIA_SERVER_URL = "https://www.boarlog.site/enter-room";
   const pc_config = {
     iceServers: [
       {


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
close #183 `강의 참여 시 발표자의 화면 로딩 시간이 길어지거나 아예 보이지 않는 이슈`

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- [x] 참여자가 강의 참여시 발표자의 화면을 바로 확인할 수 있다.
- [x] 강의자가 미디어 서버와 소켓을 연결 실패할 경우 에러 toast를 띄운다.
- [x] 강의자가 미디어 서버와 연결이 정상적으로 완료된 경우에만 안내 toast를 띄우고 타이머를 작동시킨다.
- [x] (추가로 나중을 대비하여 json 형태로 화이트보드를 공유할 수 있도록 화이트보드 내용과 현재 보고있는 좌표, 줌인 정도를 저장/불러오기 하는 함수를 구현해 두었습니다.) 


https://github.com/boostcampwm2023/web13_Boarlog/assets/86391351/d36cf45d-428f-4bf1-83b5-cc2f19489940

로컬에서 미디어 서버를 실행시켜 확인한 결과입니다.
발표자가 화이트보드를 건드리지 않아도 참여자 페이지에서 바로 화면이 보입니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

노션 개발일지에 아래 내용을 정리했습니다.
https://weak-sugar-603.notion.site/eaa2870a3d194b06a2773605e63db3a5

### 원인 분석/문제 해결 시도

**1) 화이트보드 화면이 언제 참여자 페이지에 렌더링 되는 건지 확인하기**

(로컬에 미디어 서버를 띄우고 테스트해봤습니다.)

https://github.com/boostcampwm2023/web13_Boarlog/assets/86391351/6578f06d-a1a9-4b67-a683-e0a59cb8ac8e

 video의 메타데이터가 로드되었을 때 발생하는 `loadedmetadata` 와 함께 화면에 영상이 재생되는 것을 확인했습니다. 

**2) `loadedmetadata` 가 왜 늦게 발생하는가?**

여러가지 시도 끝에 알게 된 것은 강의자 페이지에서 **강의자가 캔버스에 아무런 동작(펜 그리기, 이동, 줌인 등)을 하지 않으면** 상대방에게 `loadedmetadata` 는 일어나지 않는다는 것입니다.

https://w3c.github.io/mediacapture-fromelement/#methods-0

이는 `CaptureStream()` 의 알고리즘 문제로, 캔버스에서 **내용이 변경**될 때까지 캡처된 트랙이 시작되지 않기 때문으로 보입니다.

`CaptureStream()` 메서드 자체가 잘 사용되지 않고 있고, 업데이트가 거의 없어 이러한 옵션을 끄는 것이 불가능한 상태입니다.

이를 해결하는 방법으로 `CanvasCaptureMediaStreamTrack` 에는 requestFrame()이라는 함수가 있으나 track의 시작은 requestFrame() 이후 추가적인 캔버스 내용 변경시에 반영되어 문제를 해결할 수는 없었습니다.

### 해결 방법

**1) 강제로 canvas 내용을 업데이트 해서 해결하기**

fabric.canvas의 메서드인 `renderAll()` 를 onFrame 함수에 추가해서 계속 다시 렌더링 해주는 방식으로 문제를 해결했습니다.


https://github.com/boostcampwm2023/web13_Boarlog/assets/86391351/771b3b50-47df-4b52-a674-de8ebb3eff2f


변경 전 : 획을 추가해도 트랙이 시작되지 않음. canvas의 내용이 크게 변해야 전송 시작


https://github.com/boostcampwm2023/web13_Boarlog/assets/86391351/5ea55769-9322-45f5-9045-d677dd26d850


변경 후 : 강의자가 canvas에 아무런 변화를 주지 않아도 참여자에게 화면이 바로 나타남.

**2) 성능 문제는 없는지 확인하기**

성능 문제는 없는지 테스트 해보겠습니다. 첫번째로, onFrame에 `renderAll()` 함수가 추가되어 발표자 브라우저에서 오버헤드가 발생하는 일은 없는지 테스트 해보았습니다.

먼저, 저의 PC에서는 메모지나 선을 여러 개 생성하고 움직임을 해보아도 특별히 버벅임이나 CPU 사용량이 증가하지는 않았으나, 보다 정확한 차이를 확인하기 위해 개발자도구의 성능 탭을 활용하여 비교해 보았습니다.

<img width="824" alt="스크린샷 2023-12-03 220615" src="https://github.com/boostcampwm2023/web13_Boarlog/assets/86391351/d38d76fc-d385-4e65-885a-5a1591f5f090">
<img width="824" alt="스크린샷 2023-12-03 220243" src="https://github.com/boostcampwm2023/web13_Boarlog/assets/86391351/2e7d2c03-3bdc-48f5-ae6f-9c5d08534ac3">


동일하게 10초간 성능을 측정해 보았고, 5초 즈음에 강의 시작 버튼을 눌러 측정해본 결과입니다.

위가 `renderAll()` 함수가 없을 때의 결과이고, 아래가 `renderAll()` 함수가 onFrame 함수로 매 프레임마다 실행되었을 때의 결과입니다.

cpu사용량이나 프레임 등을 비교했을 때 특별한 차이는 발견하지 못했습니다.

### 정리 (선택)

추가적으로 미디어서버에 부담이 더 증가하는지, 비디오의 용량이 더 증가하는지 테스트가 필요합니다. 주중에 배포된 미디어서버를 이용해서 테스트 해보겠습니다.


## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
