### PR TITLE
Feature(#220): 강의실 입장 시 현 시점 화이트보드 데이터 전달

### DIFF
--- a/mediaServer/src/RelayServer.ts
+++ b/mediaServer/src/RelayServer.ts
@@ -92,8 +92,10 @@ export class RelayServer {
 
         await RTCPC.setRemoteDescription(data.SDP);
         const startTime = this.roomsInfo.get(data.roomId)?.startTime;
+        const currentWhiteboardData = this.roomsInfo.get(data.roomId)?.currentWhiteboardData;
         const SDP = await RTCPC.createAnswer();
         this.io.of('/enter-room').to(email).emit(`serverAnswer`, {
+          whiteboard: currentWhiteboardData,
           startTime: startTime,
           SDP: SDP
         });
@@ -147,6 +149,7 @@ export class RelayServer {
         console.log('해당 발표자가 존재하지 않습니다.');
         return;
       }
+      roomInfo.currentWhiteboardData = data.content;
       this.io.of('/lecture').to(clientInfo.roomId).emit('update', new Message(data.type, data.content));
     });
 

--- a/mediaServer/src/models/RoomInfo.ts
+++ b/mediaServer/src/models/RoomInfo.ts
@@ -2,6 +2,14 @@ import { RTCPeerConnection } from 'wrtc';
 import { Socket } from 'socket.io';
 import { ClientInfo } from './ClientInfo';
 
+interface ICanvasData {
+  canvasJSON: string;
+  viewport: number[];
+  eventTime: number;
+  width: number;
+  height: number;
+}
+
 export class RoomInfo {
   private readonly _roomId: string;
   private _presenterSocket: Socket | null;
@@ -10,6 +18,7 @@ export class RoomInfo {
   private readonly _studentInfoList: Set<ClientInfo>;
   private readonly _startTime: Date;
   private _stream: MediaStream | null;
+  private _currentWhiteboardData: ICanvasData | null;
 
   constructor(roomId: string, email: string, RTCPC: RTCPeerConnection) {
     this._roomId = roomId;
@@ -19,6 +28,7 @@ export class RoomInfo {
     this._studentInfoList = new Set();
     this._startTime = new Date();
     this._stream = null;
+    this._currentWhiteboardData = null;
   }
 
   get presenterEmail(): string {
@@ -43,6 +53,14 @@ export class RoomInfo {
 
   get stream(): MediaStream | null {
     return this._stream;
+  }
+
+  get currentWhiteboardData(): ICanvasData | null {
+    return this._currentWhiteboardData;
+  }
+
+  set currentWhiteboardData(data: ICanvasData) {
+    this._currentWhiteboardData = data;
   }
 
   endLecture = () => {


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
강의실 입장 시 현 시점 화이트보드 데이터 전달 close #220 

기존에는 강의 중간에 참여 시, 발표자가 화이트보드를 수정하기 전까지 현 시점의 화이트보드를 받아볼 수 없었습니다.
따라서 미디어 서버에서 최신의 화이트보드 내용을 가지고 있다가, 새로운 참여자가 강의실에 입장하면 해당 데이터를 내려주는 방식으로 해결했습니다.

하지만, 현재 미디어 서버에서 가지고 있는 데이터가 너무 많아서, 추후 역할 분리를 해보려합니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
 - [x] 발표자의 최신 화이트보드 내용을 저장한다.
 - [x] 강의실에 참여자가 입장하면, 강의실 정보에 저장되어 있는 최신 화이트보드 내용을 전달한다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->

