### PR TITLE
Fix(#222): 발표자의 음성만 참여자에게 전달하고, 강의 종료 시 음성 파일로 저장한다.

### DIFF
--- a/mediaServer/src/config/ffmpeg.config.ts
+++ b/mediaServer/src/config/ffmpeg.config.ts
@@ -1,4 +1,4 @@
-const videoConfig = (size: string) => ['-f', 'rawvideo', '-pix_fmt', 'yuv420p', '-s', size, '-r', '30'];
+// const videoConfig = (size: string) => ['-f', 'rawvideo', '-pix_fmt', 'yuv420p', '-s', size, '-r', '30'];
 const audioConfig = ['-f s16le', '-ar 48k', '-ac 1'];
 
-export { videoConfig, audioConfig };
+export { audioConfig };

--- a/mediaServer/src/models/FfmpegCommand.ts
+++ b/mediaServer/src/models/FfmpegCommand.ts
@@ -1,32 +1,28 @@
 import ffmpeg from 'fluent-ffmpeg';
-import { audioConfig, videoConfig } from '../config/ffmpeg.config';
-import { uploadFileToObjectStorage } from '../utils/ncp-storage';
+import { audioConfig } from '../config/ffmpeg.config';
 import { PeerStreamInfo } from './PeerStreamInfo';
+import { uploadFileToObjectStorage } from '../utils/ncp-storage';
 
 export class FfmpegCommand {
   private readonly _command: ffmpeg.FfmpegCommand;
 
   constructor(
-    videoTempFilePath: string,
     audioTempFilePath: string,
     recordFilePath: string,
-    videoSize: string,
     roomId: string,
     streamInfo: PeerStreamInfo,
     endRecording: (roomId: string) => void
   ) {
     this._command = ffmpeg()
-      .addInput(videoTempFilePath)
-      .addInputOptions(videoConfig(videoSize))
       .addInput(audioTempFilePath)
       .addInputOptions(audioConfig)
       .on('start', () => {
-        console.log(`${roomId} 강의실 영상 녹화 시작`);
+        console.log(`${roomId} 강의실 음성 녹화 시작`);
       })
       .on('end', async () => {
         streamInfo.recordEnd = true;
         endRecording(roomId);
-        console.log(`${roomId} 강의실 영상 녹화 종료`);
+        console.log(`${roomId} 강의실 음성 녹화 종료`);
 
         const url = await uploadFileToObjectStorage(recordFilePath, roomId);
         console.log(`${url}에 파일 저장`);
@@ -40,7 +36,6 @@ export class FfmpegCommand {
           })
         });
       })
-      .size(videoSize)
       .output(recordFilePath);
   }
 

--- a/mediaServer/src/models/PeerStreamInfo.ts
+++ b/mediaServer/src/models/PeerStreamInfo.ts
@@ -1,39 +1,25 @@
 import { PassThrough } from 'stream';
 import { FfmpegCommand } from './FfmpegCommand';
-import { RTCAudioSink, RTCVideoSink } from 'wrtc';
+import { RTCAudioSink } from 'wrtc';
 
 interface MediaFileNameList {
-  videoTempFile: string;
   audioTempFile: string;
   recordFile: string;
 }
 
-interface SinkList {
-  videoSink: RTCVideoSink;
-  audioSink: RTCAudioSink;
-}
-
 export class PeerStreamInfo {
-  private readonly _sinkList: SinkList;
+  private readonly _audioSink: RTCAudioSink;
   private readonly _mediaFileNameList: MediaFileNameList;
-  private readonly _videoSize: string;
-  private readonly _video: PassThrough;
   private readonly _audio: PassThrough;
   private _recordEnd: boolean;
   private _proc: FfmpegCommand | null;
 
-  constructor(videoSink: RTCVideoSink, audioSink: RTCAudioSink, roomId: string, videoSize: string) {
-    this._sinkList = this.setSinks(videoSink, audioSink);
+  constructor(audioSink: RTCAudioSink, roomId: string) {
+    this._audioSink = audioSink;
     this._mediaFileNameList = this.setFileName(roomId);
-    this._videoSize = videoSize;
-    this._video = new PassThrough();
     this._audio = new PassThrough();
     this._recordEnd = false;
     this._proc = null;
-  }
-
-  get videoTempFileName(): string {
-    return this._mediaFileNameList.videoTempFile;
   }
 
   get audioTempFileName(): string {
@@ -42,14 +28,6 @@ export class PeerStreamInfo {
 
   get recordFileName(): string {
     return this._mediaFileNameList.recordFile;
-  }
-
-  get videoSize(): string {
-    return this._videoSize;
-  }
-
-  get video(): PassThrough {
-    return this._video;
   }
 
   get audio(): PassThrough {
@@ -68,25 +46,15 @@ export class PeerStreamInfo {
     this._proc = FfmpegCommand;
   }
 
-  setSinks = (videoSink: RTCVideoSink, audioSink: RTCAudioSink): SinkList => {
-    return {
-      videoSink: videoSink,
-      audioSink: audioSink
-    };
-  };
-
   setFileName = (roomId: string): MediaFileNameList => {
     return {
-      videoTempFile: `video-${roomId}.sock`,
       audioTempFile: `audio-${roomId}.sock`,
-      recordFile: `lecture-${roomId}.mp4`
+      recordFile: `lecture-${roomId}.mp3`
     };
   };
 
   stopRecording = () => {
-    this._sinkList.videoSink.stop();
-    this._sinkList.audioSink.stop();
-    this._video.end();
+    this._audioSink.stop();
     this._audio.end();
   };
 }

--- a/mediaServer/src/utils/MediaConverter.ts
+++ b/mediaServer/src/utils/MediaConverter.ts
@@ -1,7 +1,7 @@
-import wrtc, { RTCAudioSink, RTCVideoSink } from 'wrtc';
+import wrtc, { RTCAudioSink } from 'wrtc';
 import { PassThrough } from 'stream';
 import fs from 'fs';
-const { RTCAudioSink, RTCVideoSink } = wrtc.nonstandard;
+const { RTCAudioSink } = wrtc.nonstandard;
 import ffmpeg from 'fluent-ffmpeg';
 import ffmpegPath from '@ffmpeg-installer/ffmpeg';
 import path from 'path';
@@ -20,37 +20,23 @@ class MediaConverter {
   }
 
   setSink = (tracks: MediaStream, roomId: string) => {
-    let videoSink: any;
     let audioSink: any;
     tracks.getTracks().forEach((track) => {
-      if (track.kind === 'video') {
-        videoSink = new RTCVideoSink(track);
-      }
       if (track.kind === 'audio') {
         audioSink = new RTCAudioSink(track);
       }
     });
-    this.startRecording(videoSink, audioSink, roomId);
+    this.startRecording(audioSink, roomId);
   };
 
-  startRecording = (videoSink: RTCVideoSink, audioSink: RTCAudioSink, roomId: string) => {
-    videoSink.onframe = ({ frame: { width, height, data } }) => {
+  startRecording = (audioSink: RTCAudioSink, roomId: string) => {
+    audioSink.ondata = ({ samples: { buffer } }) => {
       if (!this.peerStreamInfoList.has(roomId)) {
-        const streamInfo = new PeerStreamInfo(videoSink, audioSink, roomId, `${width}x${height}`);
-        this.peerStreamInfoList.set(roomId, streamInfo);
-        audioSink.ondata = ({ samples: { buffer } }) => {
-          this.pushAudioSample(stream, buffer);
-        };
+        this.peerStreamInfoList.set(roomId, new PeerStreamInfo(audioSink, roomId));
       }
       const stream = this.peerStreamInfoList.get(roomId) as PeerStreamInfo;
-      this.pushVideoFrame(stream, data);
+      this.pushAudioSample(stream, buffer);
     };
-  };
-
-  pushVideoFrame = (streamInfo: PeerStreamInfo, buffer: ArrayBufferLike) => {
-    if (!streamInfo.recordEnd) {
-      streamInfo.video.push(Buffer.from(buffer));
-    }
   };
 
   pushAudioSample = (streamInfo: PeerStreamInfo, buffer: ArrayBufferLike) => {
@@ -65,13 +51,10 @@ class MediaConverter {
       console.log('해당 강의실 발표자가 존재하지 않습니다.');
       return;
     }
-    this.mediaStreamToFile(streamInfo.video, streamInfo.videoTempFileName);
     this.mediaStreamToFile(streamInfo.audio, streamInfo.audioTempFileName);
     streamInfo.proc = new FfmpegCommand(
-      this.getOutputAbsolutePath(streamInfo.videoTempFileName),
       this.getOutputAbsolutePath(streamInfo.audioTempFileName),
       this.getOutputAbsolutePath(streamInfo.recordFileName),
-      streamInfo.videoSize,
       roomId,
       streamInfo,
       this.endRecording
@@ -93,7 +76,6 @@ class MediaConverter {
       return;
     }
     streamInfo.stopRecording();
-    this.deleteTempFile(streamInfo.videoTempFileName);
     this.deleteTempFile(streamInfo.audioTempFileName);
     this.peerStreamInfoList.delete(roomId);
   };


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
발표자의 음성만 참여자에게 전달하고, 강의 종료 시 음성 파일로 저장되도록 구성한다. close #222

화이트보드 변경 사항은 JSON 형태로 전달하도록 구성했기 때문에, 발표자의 화이트보드 영상과 음성을 참여자에게 전달하는 것이 아닌 발표자의 음성만 전달한다. 또한 강의 종료 시 음성 파일로 저장하도록 변경했다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
기존 영상과 음성을 모두 전달하도록 했으나 음성만 전달하고, 음성 스트림을 바탕으로 음성 파일로 만들도록 구성했다.

- [x] ffmpeg-command에서 비디오 저장 옵션 삭제