### PR TITLE
Fix: NCP에 파일 업로드 시 mp3 확장자로 저장될 수 있도록 확장자 변경

### DIFF
--- a/mediaServer/src/utils/ncp-storage.ts
+++ b/mediaServer/src/utils/ncp-storage.ts
@@ -7,7 +7,7 @@ const bucketName = process.env.NCP_BUCKET_NAME as string;
 const uploadFileToObjectStorage = async (file: any, filename: string) => {
   await S3.putObject({
     Bucket: bucketName,
-    Key: `${filename}.mp4`,
+    Key: `${filename}.mp3`,
     ACL: 'public-read',
     Body: fs.createReadStream(file)
   }).promise();


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
이전에 mp4 형식으로 파일을 저장하도록 진행했는데, 미처 NCP에 저장될 파일 확장자를 수정하지 않아서 mp3로 변경했습니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- [x] NCP에 업로드 할 파일의 확장자를 mp3로 변경 