### PR TITLE
Refact/231207 new question focus

### DIFF
--- a/frontend/src/components/LogContainer/LogContainer.tsx
+++ b/frontend/src/components/LogContainer/LogContainer.tsx
@@ -32,19 +32,27 @@ const LogContainer = ({ type, className }: LogContainerInterface) => {
   const [questionList, setQuestionList] = useState<Array<{ title: string; contents: string }>>([]);
   const [scriptList, setScriptList] = useState<Array<{ start: string; text: string }>>([]);
   const messageInputRef = useRef<HTMLInputElement | null>(null);
+  const logContainerRef = useRef<HTMLUListElement | null>(null);
   const socket = useRecoilValue(participantSocketRefState);
   const roomid = new URLSearchParams(useLocation().search).get("roomid") || "999999";
 
-  useEffect(() => {
-    axios("./reviewLecture.json")
-      .then(({ data }) => {
-        // @ts-ignore
-        setScriptList(data);
-      })
-      .catch((error) => {
-        console.log("프롬프트에 표시할 스크립트 로딩 실패", error);
-      });
-  }, []);
+  if (type === "prompt") {
+    useEffect(() => {
+      console.log("p");
+      axios("./reviewLecture.json")
+        .then(({ data }) => {
+          setScriptList(data);
+        })
+        .catch((error) => {
+          console.log("프롬프트에 표시할 스크립트 로딩 실패", error);
+        });
+    }, []);
+  } else {
+    useEffect(() => {
+      if (!logContainerRef.current) return;
+      logContainerRef.current.scrollTop = logContainerRef.current?.scrollHeight;
+    }, [questionList]);
+  }
 
   const handleInputChange = () => {
     if (!messageInputRef.current) return;
@@ -90,7 +98,7 @@ const LogContainer = ({ type, className }: LogContainerInterface) => {
         {type === "question" ? "질문하기" : "강의 프롬프트"}
       </h2>
       {type === "question" && (
-        <ul className="px-4 flex-grow overflow-y-auto	">
+        <ul className="px-4 flex-grow overflow-y-auto	" ref={logContainerRef}>
           {questionList.map(({ title, contents }, index) => {
             return <LogItem key={`k-${index}`} title={title} contents={contents} />;
           })}

--- a/frontend/src/components/LogContainer/LogContainer.tsx
+++ b/frontend/src/components/LogContainer/LogContainer.tsx
@@ -38,7 +38,6 @@ const LogContainer = ({ type, className }: LogContainerInterface) => {
 
   if (type === "prompt") {
     useEffect(() => {
-      console.log("p");
       axios("./reviewLecture.json")
         .then(({ data }) => {
           setScriptList(data);

--- a/frontend/src/components/LogContainer/LogContainer.tsx
+++ b/frontend/src/components/LogContainer/LogContainer.tsx
@@ -4,6 +4,7 @@ import participantSocketRefState from "@/stores/stateParticipantSocketRef";
 import { useEffect, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { useLocation } from "react-router-dom";
+import convertMsToTimeString from "@/utils/convertMsToTimeString";
 import axios from "axios";
 
 interface LogItemInterface {
@@ -25,20 +26,6 @@ const LogItem = ({ title, contents }: LogItemInterface) => {
     </li>
   );
 };
-
-function convertMsToTimeString(ms: string) {
-  let msNumber = parseInt(ms);
-  let seconds = Math.floor(msNumber / 1000);
-  let hours = Math.floor(seconds / 3600);
-  seconds = seconds % 3600;
-
-  let minutes = Math.floor(seconds / 60);
-  seconds = seconds % 60;
-
-  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds
-    .toString()
-    .padStart(2, "0")}`;
-}
 
 const LogContainer = ({ type, className }: LogContainerInterface) => {
   const [isInputEmpty, setIsInputEmpty] = useState<boolean>(true);

--- a/frontend/src/pages/Participant/Participant.tsx
+++ b/frontend/src/pages/Participant/Participant.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useSetRecoilState, useRecoilValue } from "recoil";
 import { fabric } from "fabric";
-import CloseIcon from "@/assets/svgs/close.svg?react";
-import QuestionIcon from "@/assets/svgs/whiteboard/question.svg?react";
 
 import Header from "@/components/Header/Header";
 import participantCavasInstanceState from "@/stores/stateParticipantCanvasInstance";

--- a/frontend/src/pages/Participant/Participant.tsx
+++ b/frontend/src/pages/Participant/Participant.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef } from "react";
 import { useSetRecoilState, useRecoilValue } from "recoil";
 import { fabric } from "fabric";
+import CloseIcon from "@/assets/svgs/close.svg?react";
+import QuestionIcon from "@/assets/svgs/whiteboard/question.svg?react";
 
 import Header from "@/components/Header/Header";
 import participantCavasInstanceState from "@/stores/stateParticipantCanvasInstance";
-import QuestionLogButton from "./components/QuestionLogButton";
+import LogToggleButton from "@/components/Button/LogToggleButton";
 import LogContainer from "@/components/LogContainer/LogContainer";
 
 import isQuestionLogOpenState from "@/stores/stateIsQuestionLogOpen";

--- a/frontend/src/pages/Review/components/ProgressBar.tsx
+++ b/frontend/src/pages/Review/components/ProgressBar.tsx
@@ -18,7 +18,7 @@ const ProgressBar = ({ className }: { className: string }) => {
         {isPlaying ? <PlayIcon /> : <PauseIcon />}
       </button>
       <div className="relative grow h-1  bg-grayscale-lightgray">
-        <div className="absolute top-0 left-0 h-1 w-[50%] bg-boarlog-100"></div>
+        <div className="absolute top-0 left-0 h-1 w-1/2 bg-boarlog-100"></div>
       </div>
       <span className="medium-12">00:00:00</span>
     </div>

--- a/frontend/src/pages/Test/components/CanvasSection.tsx
+++ b/frontend/src/pages/Test/components/CanvasSection.tsx
@@ -28,7 +28,7 @@ const CanvasSection = () => {
   useEffect(() => {
     if (!socket) return;
     socket.on("asked", (data) => {
-      setQuestions([...questions, data.content]);
+      setQuestions([data.content, ...questions]);
     });
   }, [socket, questions]);
 

--- a/frontend/src/pages/Test/components/QuestionButton.tsx
+++ b/frontend/src/pages/Test/components/QuestionButton.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 const IndicatorBubble = ({ count }: { count: number }) => {
   return (
     <>
-      <div className="animate-ping absolute -top-2 -right-2 rounded-xl w-5 h-5  bg-alert-100"></div>
+      <div className="animate-ping absolute -top-2 -right-2 rounded-xl w-5 h-5 z-10  bg-alert-100"></div>
       <div className="absolute -top-2 -right-2 flex justify-center items-center rounded-xl w-5 h-5  bg-alert-100 medium-12 text-grayscale-white">
         {count}
       </div>

--- a/frontend/src/pages/Test/components/QuestionList.tsx
+++ b/frontend/src/pages/Test/components/QuestionList.tsx
@@ -25,7 +25,7 @@ const QuestionList = () => {
   return (
     <section className="w-60 h-[41rem] border border-default rounded-xl absolute top-2.5 left-20 mb-6 bg-grayscale-white">
       <h2 className="semibold-18 inline-block mt-1 p-4">질문 리스트</h2>
-      <div className="h-[36rem] px-4 overflow-scroll">
+      <div className="h-[36rem] px-4 overflow-y-auto">
         <ul ref={listRef}>
           {questions.map((question, index) => (
             <li className={`p-4 h-fit mb-4 min-h-[6.25rem] ${MEMO_COLOR} relative`} key={index}>

--- a/frontend/src/pages/Test/components/QuestionList.tsx
+++ b/frontend/src/pages/Test/components/QuestionList.tsx
@@ -7,19 +7,7 @@ import activeToolState from "./stateActiveTool";
 import questionListState from "./stateQuestionList";
 import clickedQuestionContentsState from "./stateClickedQuestionContents";
 
-const COLOR_SET = [
-  { background: "bg-memo-red", border: "border-memo-border-red" },
-  { background: "bg-memo-yellow", border: "border-memo-border-yellow" },
-  { background: "bg-memo-forsythia", border: "border-memo-border-forsythia" },
-  { background: "bg-memo-lightgreen", border: "border-memo-border-lightgreen" },
-  { background: "bg-memo-blue", border: "border-memo-border-blue" }
-];
-
-const getColorSetByIndex = (index: number) => {
-  const randomIndex = index % COLOR_SET.length;
-
-  return COLOR_SET[randomIndex].background + " " + COLOR_SET[randomIndex].border;
-};
+const MEMO_COLOR = "bg-memo-yellow border-memo-border-yellow";
 
 const QuestionList = () => {
   const listRef = useRef<HTMLUListElement>(null);
@@ -40,7 +28,7 @@ const QuestionList = () => {
       <div className="h-[36rem] px-4 overflow-scroll">
         <ul ref={listRef}>
           {questions.map((question, index) => (
-            <li className={`p-4 h-fit mb-4 min-h-[6.25rem] ${getColorSetByIndex(index)} relative`} key={index}>
+            <li className={`p-4 h-fit mb-4 min-h-[6.25rem] ${MEMO_COLOR} relative`} key={index}>
               <div className="flex justify-center items-center h-[100%] w-[100%] bg-black/30 absolute top-0 left-0 opacity-0 hover:opacity-100">
                 <button
                   type="button"

--- a/frontend/src/utils/convertMsToTimeString.ts
+++ b/frontend/src/utils/convertMsToTimeString.ts
@@ -1,10 +1,14 @@
+const MS_OF_SECOND = 1000;
+const SECOND_OF_HOUR = 3600;
+const MINUTE_OF_HOUR = 60;
+
 const convertMsToTimeString = (ms: string) => {
   let msNumber = parseInt(ms);
-  let seconds = Math.floor(msNumber / 1000);
-  let hours = Math.floor(seconds / 3600);
+  let seconds = Math.floor(msNumber / MS_OF_SECOND);
+  let hours = Math.floor(seconds / SECOND_OF_HOUR);
   seconds = seconds % 3600;
 
-  let minutes = Math.floor(seconds / 60);
+  let minutes = Math.floor(seconds / MINUTE_OF_HOUR);
   seconds = seconds % 60;
 
   return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds

--- a/frontend/src/utils/convertMsToTimeString.ts
+++ b/frontend/src/utils/convertMsToTimeString.ts
@@ -1,0 +1,14 @@
+const convertMsToTimeString = (ms: string) => {
+  let msNumber = parseInt(ms);
+  let seconds = Math.floor(msNumber / 1000);
+  let hours = Math.floor(seconds / 3600);
+  seconds = seconds % 3600;
+
+  let minutes = Math.floor(seconds / 60);
+  seconds = seconds % 60;
+
+  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds
+    .toString()
+    .padStart(2, "0")}`;
+};
+export default convertMsToTimeString;


### PR DESCRIPTION
## 작업 개요
질문리스트, 질문 채팅 관련 사용성 개선

- Refactor: 질문 리스트의 메모지 색 통일 close #218
- Refactor: 참여자, 발표자 최신 질문에 대한 사용성 개선 close #216

## 작업 사항

1.  질문 리스트의 메모지 색 통일 #218

- 기존: 5가지 색으로 인덱스에 따라 색 지정
- 개선: 리스트에 생성되는 메모지의 색을 노란색으로 고정해 화이트보드에 생성되는 메모지의 색과 일치시켰습니다.

2. 발표자-질문리스트 새로운 질문 상단에 생성 #216

3. 발표자-버블의 알림 애니메이션이 헤더 밑으로 깔리는 문제 해결

4. 참여자-질문 채팅 새로운 질문으로 스크롤 이동 #216


## 고민한 점들(필수 X)


## 스크린샷(필수 X)

- 버블 개선 전

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/6e9b0ad0-83d0-48b8-84a6-fb1122cddd9f

- 버블 개선 후

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/f1b3d387-15df-485c-ac2d-88e601059ef5

- 질문 채팅 개선 전

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/ae29d36c-758b-46e7-9a1b-bf635fded7b9

- 질문 채팅 개선 후

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/3772bdbc-095f-4ebc-8eb7-21c925251935

- 질문 리스트 개선 전

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/90fd707b-75ff-4835-a5e8-c7ae0caf0f55


- 질문 리스트 개선 후

https://github.com/boostcampwm2023/web13_Boarlog/assets/54176384/5347c521-491b-4dd1-9707-17db9ef0e26d


 
