### PR TITLE
Refactor(#217): 화이트보드-backspace로 그래픽 요소 지우기 구현

### DIFF
--- a/frontend/src/pages/Test/components/CanvasSection.tsx
+++ b/frontend/src/pages/Test/components/CanvasSection.tsx
@@ -79,7 +79,7 @@ const CanvasSection = () => {
         newCanvas.discardActiveObject(); // 선택 해제
       }
     };
-    window.addEventListener("keydown", handleDelete);
+    window.addEventListener("keyup", handleDelete);
 
     // 처음 접속했을 때 캔버스에 그리기 가능하도록 설정
     newCanvas.freeDrawingBrush.width = 10;

--- a/frontend/src/pages/Test/components/CanvasSection.tsx
+++ b/frontend/src/pages/Test/components/CanvasSection.tsx
@@ -68,7 +68,8 @@ const CanvasSection = () => {
     window.addEventListener("resize", handleResize);
 
     // delete 키를 이용해서 선택된 객체 삭제
-    const handleDelete = () => {
+    const handleDelete = ({ key, code }: { key: string; code: string }) => {
+      if (!(code === "Delete" || key === "Delete" || code === "Backspace" || key === "Backspace")) return;
       const activeObjects = newCanvas.getActiveObjects();
       if (activeObjects && activeObjects.length > 0) {
         // 선택된 모든 객체 삭제
@@ -78,11 +79,7 @@ const CanvasSection = () => {
         newCanvas.discardActiveObject(); // 선택 해제
       }
     };
-    window.addEventListener("keydown", (e) => {
-      if (e.code === "Delete" || e.key === "Delete") {
-        handleDelete();
-      }
-    });
+    window.addEventListener("keydown", handleDelete);
 
     // 처음 접속했을 때 캔버스에 그리기 가능하도록 설정
     newCanvas.freeDrawingBrush.width = 10;
@@ -95,6 +92,7 @@ const CanvasSection = () => {
     return () => {
       newCanvas.dispose();
       window.removeEventListener("resize", handleResize);
+      window.removeEventListener("keyup", handleDelete);
     };
   }, []);
 


### PR DESCRIPTION
## 작업 개요

화이트보드-backspace로 그래픽 요소 지우기 구현 close #217

## 작업 사항

- [x] backspace로 그래픽 요소 지우기 구현
- [x] keydown 이벤트의 경우 눌려있는 경우 계속 이벤트가 발생하기 때문에 keyup 이벤트로 변경
- [x] 언마운트시 이벤트 제거 

## 고민한 점들(필수 X)


## 스크린샷(필수 X)

