### PR TITLE
Refactor: 강의자/참여자 헤더 리팩토링

### DIFF
--- a/frontend/src/components/Header/components/HeaderInstructorControls.tsx
+++ b/frontend/src/components/Header/components/HeaderInstructorControls.tsx
@@ -222,8 +222,8 @@ const HeaderInstructorControls = ({ setLectureCode }: HeaderInstructorControlsPr
     updatedStreamRef.current = mediaStreamDestination.stream;
 
     const onFrame = () => {
-      saveCanvasData(fabricCanvasRef!, canvasData, startTime).then(() => {
-        submitData(canvasData);
+      saveCanvasData(fabricCanvasRef!, canvasData, startTime).then((isChanged) => {
+        if (isChanged) submitData(canvasData);
       });
       gainNode.gain.value = inputMicVolumeRef.current;
       setMicVolumeState(calcNormalizedVolume(analyser));

--- a/frontend/src/components/Header/components/HeaderInstructorControls.tsx
+++ b/frontend/src/components/Header/components/HeaderInstructorControls.tsx
@@ -11,8 +11,10 @@ import MicOnIcon from "@/assets/svgs/micOn.svg?react";
 import MicOffIcon from "@/assets/svgs/micOff.svg?react";
 import SmallButton from "@/components/SmallButton/SmallButton";
 import Modal from "@/components/Modal/Modal";
+
 import { useToast } from "@/components/Toast/useToast";
 import { ICanvasData, saveCanvasData } from "./fabricCanvasUtil";
+import calcNormalizedVolume from "@/utils/calcNormalizedVolume";
 
 import selectedMicrophoneState from "@/stores/stateSelectedMicrophone";
 import micVolumeGainState from "@/stores/stateMicVolumeGain";
@@ -254,24 +256,12 @@ const HeaderInstructorControls = ({ setLectureCode }: HeaderInstructorControlsPr
     // 업데이트된 미디어 스트림을 앞으로 참조하도록 설정
     updatedStreamRef.current = mediaStreamDestination.stream;
 
-    const pcmData = new Float32Array(analyser.fftSize);
-
     const onFrame = () => {
-      if (!fabricCanvasRef) return;
-      saveCanvasData(fabricCanvasRef, canvasData, startTime).then(() => {
+      saveCanvasData(fabricCanvasRef!, canvasData, startTime).then(() => {
         submitData(canvasData);
       });
-
       gainNode.gain.value = inputMicVolumeRef.current;
-
-      analyser.getFloatTimeDomainData(pcmData);
-      let sum = 0.0;
-      for (const amplitude of pcmData) {
-        sum += amplitude * amplitude;
-      }
-      const rms = Math.sqrt(sum / pcmData.length);
-      const normalizedVolume = Math.min(1, rms / 0.5);
-      setMicVolumeState(normalizedVolume);
+      setMicVolumeState(calcNormalizedVolume(analyser));
       onFrameIdRef.current = window.requestAnimationFrame(onFrame);
     };
     onFrameIdRef.current = window.requestAnimationFrame(onFrame);

--- a/frontend/src/components/Header/components/HeaderInstructorControls.tsx
+++ b/frontend/src/components/Header/components/HeaderInstructorControls.tsx
@@ -47,7 +47,7 @@ const HeaderInstructorControls = ({ setLectureCode }: HeaderInstructorControlsPr
   const onFrameIdRef = useRef<number | null>(null); // 마이크 볼륨 측정 타이머 id
   const managerRef = useRef<Manager>();
   const socketRef = useRef<Socket>();
-  const socketRef2 = useRef<Socket>();
+  const lectureSocketRef = useRef<Socket>();
   const pcRef = useRef<RTCPeerConnection>();
   const mediaStreamRef = useRef<MediaStream>();
   const updatedStreamRef = useRef<MediaStream>();
@@ -101,8 +101,8 @@ const HeaderInstructorControls = ({ setLectureCode }: HeaderInstructorControlsPr
     isLectureStartRef.current = false;
     setElapsedTime(0);
 
-    if (!socketRef2.current) return;
-    socketRef2.current.emit("end", {
+    if (!lectureSocketRef.current) return;
+    lectureSocketRef.current.emit("end", {
       type: "lecture",
       roomId: roomid
     });
@@ -110,7 +110,7 @@ const HeaderInstructorControls = ({ setLectureCode }: HeaderInstructorControlsPr
     if (timerIdRef.current) clearInterval(timerIdRef.current); // 경과 시간 표시 타이머 중지
     if (onFrameIdRef.current) window.cancelAnimationFrame(onFrameIdRef.current); // 마이크 볼륨 측정 중지
     if (socketRef.current) socketRef.current.disconnect(); // 소켓 연결 해제
-    if (socketRef2.current) socketRef2.current.disconnect(); // 소켓 연결 해제
+    if (lectureSocketRef.current) lectureSocketRef.current.disconnect(); // 소켓 연결 해제
     if (pcRef.current) pcRef.current.close(); // RTCPeerConnection 해제
     if (mediaStreamRef.current) mediaStreamRef.current.getTracks().forEach((track) => track.stop()); // 미디어 트랙 중지
 
@@ -285,8 +285,8 @@ const HeaderInstructorControls = ({ setLectureCode }: HeaderInstructorControlsPr
   };
 
   const submitData = (data: ICanvasData) => {
-    if (!socketRef2.current) return;
-    socketRef2.current.emit("edit", {
+    if (!lectureSocketRef.current) return;
+    lectureSocketRef.current.emit("edit", {
       type: "whiteBoard",
       roomId: roomid,
       content: data
@@ -309,13 +309,13 @@ const HeaderInstructorControls = ({ setLectureCode }: HeaderInstructorControlsPr
     startTimer();
     showToast({ message: "강의가 시작되었습니다.", type: "success" });
     if (!managerRef.current) return;
-    socketRef2.current = managerRef.current.socket("/lecture", {
+    lectureSocketRef.current = managerRef.current.socket("/lecture", {
       auth: {
         accessToken: sampleAccessToken,
         refreshToken: "sample"
       }
     });
-    setInstructorSocket(socketRef2.current);
+    setInstructorSocket(lectureSocketRef.current);
     submitData(canvasData);
   };
   const handleServerError = (err: any) => {

--- a/frontend/src/components/Header/components/HeaderParticipantControls.tsx
+++ b/frontend/src/components/Header/components/HeaderParticipantControls.tsx
@@ -3,7 +3,6 @@ import { useState, useRef, useEffect } from "react";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { Socket, Manager } from "socket.io-client";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useToast } from "@/components/Toast/useToast";
 
 import VolumeMeter from "./VolumeMeter";
 import StopIcon from "@/assets/svgs/stop.svg?react";
@@ -11,7 +10,10 @@ import MicOnIcon from "@/assets/svgs/micOn.svg?react";
 import MicOffIcon from "@/assets/svgs/micOff.svg?react";
 import SmallButton from "@/components/SmallButton/SmallButton";
 import Modal from "@/components/Modal/Modal";
+
+import { useToast } from "@/components/Toast/useToast";
 import { ICanvasData, loadCanvasData } from "./fabricCanvasUtil";
+import calcNormalizedVolume from "@/utils/calcNormalizedVolume";
 
 import selectedSpeakerState from "@/stores/stateSelectedSpeaker";
 import speakerVolmeState from "@/stores/stateSpeakerVolume";
@@ -243,18 +245,9 @@ const HeaderParticipantControls = ({ setLectureCode }: HeaderParticipantControls
     gainNode.connect(analyser);
     gainNode.connect(destination);
 
-    const pcmData = new Float32Array(analyser.fftSize);
-
     const onFrame = () => {
       gainNode.gain.value = speakerVolumeRef.current;
-      analyser.getFloatTimeDomainData(pcmData);
-      let sum = 0.0;
-      for (const amplitude of pcmData) {
-        sum += amplitude * amplitude;
-      }
-      const rms = Math.sqrt(sum / pcmData.length);
-      const normalizedVolume = Math.min(1, rms / 0.5);
-      setMicVolumeState(normalizedVolume);
+      setMicVolumeState(calcNormalizedVolume(analyser));
       onFrameIdRef.current = window.requestAnimationFrame(onFrame);
     };
     onFrameIdRef.current = window.requestAnimationFrame(onFrame);

--- a/frontend/src/components/Header/components/HeaderParticipantControls.tsx
+++ b/frontend/src/components/Header/components/HeaderParticipantControls.tsx
@@ -42,7 +42,7 @@ const HeaderParticipantControls = ({ setLectureCode }: HeaderParticipantControls
   const onFrameIdRef = useRef<number | null>(null); // 마이크 볼륨 측정 타이머 id
   const managerRef = useRef<Manager>();
   const socketRef = useRef<Socket>();
-  const socketRef2 = useRef<Socket>();
+  const lectureSocketRef = useRef<Socket>();
   const pcRef = useRef<RTCPeerConnection>();
   const mediaStreamRef = useRef<MediaStream>();
   const localAudioRef = useRef<HTMLAudioElement>(null);
@@ -117,8 +117,8 @@ const HeaderParticipantControls = ({ setLectureCode }: HeaderParticipantControls
   };
 
   const leaveLecture = ({ isLectureEnd }: { isLectureEnd: boolean }) => {
-    if (!socketRef2.current) return;
-    socketRef2.current.emit("leave", {
+    if (!lectureSocketRef.current) return;
+    lectureSocketRef.current.emit("leave", {
       type: "lecture",
       roomId: roomid
     });
@@ -127,7 +127,7 @@ const HeaderParticipantControls = ({ setLectureCode }: HeaderParticipantControls
     if (timerIdRef.current) clearInterval(timerIdRef.current); // 경과 시간 표시 타이머 중지
     if (onFrameIdRef.current) window.cancelAnimationFrame(onFrameIdRef.current); // 마이크 볼륨 측정 중지
     if (socketRef.current) socketRef.current.disconnect(); // 소켓 연결 해제
-    if (socketRef2.current) socketRef2.current.disconnect(); // 소켓 연결 해제
+    if (lectureSocketRef.current) lectureSocketRef.current.disconnect(); // 소켓 연결 해제
     if (pcRef.current) pcRef.current.close(); // RTCPeerConnection 해제
     if (mediaStreamRef.current) mediaStreamRef.current.getTracks().forEach((track) => track.stop()); // 미디어 트랙 중지
 
@@ -257,15 +257,15 @@ const HeaderParticipantControls = ({ setLectureCode }: HeaderParticipantControls
     showToast({ message: "강의가 시작되었습니다.", type: "success" });
     showToast({ message: "우측 상단 음소거 버튼을 눌러 음소거를 해제 할 수 있습니다.", type: "alert" });
     if (!managerRef.current) return;
-    socketRef2.current = managerRef.current.socket("/lecture", {
+    lectureSocketRef.current = managerRef.current.socket("/lecture", {
       auth: {
         accessToken: sampleAccessToken,
         refreshToken: "sample"
       }
     });
-    setParticipantSocket(socketRef2.current);
-    socketRef2.current.on("ended", () => handleLectureEnd());
-    socketRef2.current.on("update", (data) => loadCanvasData(fabricCanvasRef!, canvasData, data.content));
+    setParticipantSocket(lectureSocketRef.current);
+    lectureSocketRef.current.on("ended", () => handleLectureEnd());
+    lectureSocketRef.current.on("update", (data) => loadCanvasData(fabricCanvasRef!, canvasData, data.content));
   };
 
   return (

--- a/frontend/src/components/Header/components/fabricCanvasUtil.ts
+++ b/frontend/src/components/Header/components/fabricCanvasUtil.ts
@@ -1,0 +1,64 @@
+export interface ICanvasData {
+  canvasJSON: string;
+  viewport: number[];
+  eventTime: number;
+  width: number;
+  height: number;
+}
+
+export const saveCanvasData = async (fabricCanvas: fabric.Canvas, currentData: ICanvasData, startTime: number) => {
+  if (!fabricCanvas.viewportTransform) return;
+
+  const newJSONData = JSON.stringify(fabricCanvas);
+  const newViewport = fabricCanvas.viewportTransform;
+  const newWidth = fabricCanvas.getWidth();
+  const newHeight = fabricCanvas.getHeight();
+
+  const isCanvasDataChanged = currentData.canvasJSON !== newJSONData;
+  const isViewportChanged = JSON.stringify(currentData.viewport) !== JSON.stringify(newViewport);
+  const isSizeChanged = currentData.width !== newWidth || currentData.height !== newHeight;
+
+  if (isCanvasDataChanged || isViewportChanged || isSizeChanged) {
+    currentData.canvasJSON = newJSONData;
+    currentData.viewport = newViewport;
+    currentData.eventTime = Date.now() - startTime;
+    currentData.width = newWidth;
+    currentData.height = newHeight;
+  }
+};
+export const loadCanvasData = (fabricCanvas: fabric.Canvas, currentData: ICanvasData, newData: ICanvasData) => {
+  const isCanvasDataChanged = currentData.canvasJSON !== newData.canvasJSON;
+  const isViewportChanged = JSON.stringify(currentData.viewport) !== JSON.stringify(newData.viewport);
+  const isSizeChanged = currentData.width !== newData.width || currentData.height !== newData.width;
+
+  // 캔버스 데이터 업데이트
+  if (isCanvasDataChanged) fabricCanvas.loadFromJSON(newData.canvasJSON, () => {});
+  // 캔버스 뷰포트 업데이트
+  if (isViewportChanged) fabricCanvas.setViewportTransform(newData.viewport);
+  // 캔버스 크기 업데이트
+  if (isSizeChanged) {
+    // 발표자 화이트보드 비율에 맞춰서 캔버스 크기 조정
+    const HEADER_HEIGHT = 80;
+    const newHegiht = window.innerWidth * (newData.height / newData.width);
+    if (newHegiht > window.innerHeight - HEADER_HEIGHT) {
+      const newWidth = (window.innerHeight - HEADER_HEIGHT) * (newData.width / newData.height);
+      fabricCanvas.setDimensions({
+        width: newWidth,
+        height: window.innerHeight - HEADER_HEIGHT
+      });
+    } else {
+      fabricCanvas.setDimensions({
+        width: window.innerWidth,
+        height: newHegiht
+      });
+    }
+    // 화이트보드 내용을 캔버스 크기에 맞춰서 재조정
+    fabricCanvas.setDimensions(
+      {
+        width: newData.width,
+        height: newData.height
+      },
+      { backstoreOnly: true }
+    );
+  }
+};

--- a/frontend/src/components/Header/components/fabricCanvasUtil.ts
+++ b/frontend/src/components/Header/components/fabricCanvasUtil.ts
@@ -24,6 +24,9 @@ export const saveCanvasData = async (fabricCanvas: fabric.Canvas, currentData: I
     currentData.eventTime = Date.now() - startTime;
     currentData.width = newWidth;
     currentData.height = newHeight;
+    return true;
+  } else {
+    return false;
   }
 };
 export const loadCanvasData = (fabricCanvas: fabric.Canvas, currentData: ICanvasData, newData: ICanvasData) => {

--- a/frontend/src/components/LogContainer/LogContainer.tsx
+++ b/frontend/src/components/LogContainer/LogContainer.tsx
@@ -4,7 +4,7 @@ import participantSocketRefState from "@/stores/stateParticipantSocketRef";
 import { useEffect, useRef, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { useLocation } from "react-router-dom";
-import convertMsToTimeString from "@/utils/convertMsToTimeString";
+import { convertMsToTimeString } from "@/utils/convertMsToTimeString";
 import axios from "axios";
 
 interface LogItemInterface {

--- a/frontend/src/utils/calcNormalizedVolume.ts
+++ b/frontend/src/utils/calcNormalizedVolume.ts
@@ -1,0 +1,13 @@
+export const calcNormalizedVolume = (analyser: AnalyserNode) => {
+  const pcmData = new Float32Array(analyser.fftSize);
+  analyser.getFloatTimeDomainData(pcmData);
+  let sum = 0.0;
+  for (const amplitude of pcmData) {
+    sum += amplitude * amplitude;
+  }
+  const rms = Math.sqrt(sum / pcmData.length);
+  const normalizedVolume = Math.min(1, rms / 0.5);
+  return normalizedVolume;
+};
+
+export default calcNormalizedVolume;

--- a/frontend/src/utils/convertMsToTimeString.ts
+++ b/frontend/src/utils/convertMsToTimeString.ts
@@ -2,7 +2,7 @@ const MS_OF_SECOND = 1000;
 const SECOND_OF_HOUR = 3600;
 const MINUTE_OF_HOUR = 60;
 
-const convertMsToTimeString = (ms: string) => {
+export const convertMsToTimeString = (ms: string) => {
   let msNumber = parseInt(ms);
   let seconds = Math.floor(msNumber / MS_OF_SECOND);
   let hours = Math.floor(seconds / SECOND_OF_HOUR);
@@ -15,4 +15,9 @@ const convertMsToTimeString = (ms: string) => {
     .toString()
     .padStart(2, "0")}`;
 };
-export default convertMsToTimeString;
+
+export const convertMsTohhmm = (ms: number) => {
+  return `${Math.floor(ms / 60)
+    .toString()
+    .padStart(2, "0")}:${(ms % 60).toString().padStart(2, "0")}`;
+};


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

강의자와 참여자 헤더의 코드를 간단하게 리팩토링 했습니다.
다음 PR 올릴 때 변경 사항이 많으면 코드리뷰 하시기 힘드실 것 같아서 리팩토링 한 내용만 먼저 PR 올립니다.
기능이 변한 것은 없어서 편하게 LGTM만 해주셔도 감사하겠습니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

- [x] socket 통신 관련 함수를 핸들러 함수로 분리하여 사용하고, 이벤트를 한 곳에서 등록하도록 개선했습니다.
- [x] 다시보기 페이지에서의 사용을 고려해서 캔버스 데이터를 저장하고 로드하는 함수를 별도의 파일로 분리했습니다.
- [x] AnalyserNode에서 정규화된 볼륨을 계산하는 calcNormalizedVolume, 헤더 상단 지난 시간을 표시하는 convertMsTohhmm 함수를 만들어 분리했습니다.
- [x] socketRef2 -> lectureSocketRef로 이름을 변경했습니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
여기에 작성하세요

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->
여기에 작성하세요
