### PR TITLE
Refactor(#249): 링크 공유 개선, Toast state 분리

### DIFF
--- a/frontend/src/components/Header/components/HeaderCodeCopyButton.tsx
+++ b/frontend/src/components/Header/components/HeaderCodeCopyButton.tsx
@@ -6,13 +6,17 @@ interface HeaderCodeCopyButtonProps {
   lectureCode: string;
 }
 
+const getClipboardText = (lectureCode: string) => {
+  return `[함께 듣는 실시간 강의 Boarlog]\n\n지금 진행되는 강의에 참여해 보세요.\n\n강의 코드: ${lectureCode}\n강의 제목: 화이트보드 테스트\n강의 링크: ${
+    import.meta.env.VITE_BOARLOG_BASE_URL
+  }/participant?roomid=${lectureCode}`;
+};
+
 const HeaderCodeCopyButton = ({ lectureCode }: HeaderCodeCopyButtonProps) => {
   const showToast = useToast();
   const handleShareButtonClicked = async () => {
     try {
-      await navigator.clipboard.writeText(
-        `[함께 듣는 실시간 강의 Boarlog]\n\n지금 진행되는 강의에 참여해 보세요.\n\n강의 코드: ${lectureCode}\n강의 제목: 화이트보드 테스트\n강의 링크: https://dev--boarlog.netlify.app/participant?roomid=${lectureCode}`
-      );
+      await navigator.clipboard.writeText(getClipboardText(lectureCode));
       showToast({ message: "클립보드에 강의 코드를 복사했어요.", type: "success" });
     } catch (error) {
       console.error("복사 실패:", error);

--- a/frontend/src/components/Toast/ToastContainer.tsx
+++ b/frontend/src/components/Toast/ToastContainer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useRecoilState } from "recoil";
-import { toastListState } from "./toastAtom";
+import { toastListState } from "../../stores/stateToastList";
 import { useRecoilValue } from "recoil";
 import usePortal from "./usePortal";
 import ReactDOM from "react-dom";

--- a/frontend/src/components/Toast/ToastContainer.tsx
+++ b/frontend/src/components/Toast/ToastContainer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useRecoilState } from "recoil";
-import { toastListState } from "../../stores/stateToastList";
+import { toastListState } from "@/stores/stateToastList";
 import { useRecoilValue } from "recoil";
 import usePortal from "./usePortal";
 import ReactDOM from "react-dom";

--- a/frontend/src/components/Toast/useToast.ts
+++ b/frontend/src/components/Toast/useToast.ts
@@ -1,5 +1,5 @@
 import { useSetRecoilState } from "recoil";
-import { toastListState } from "./toastAtom";
+import { toastListState } from "../../stores/stateToastList";
 import { ToastMessage } from "./toastType";
 import { TOAST_AVAILABLE_TIME } from "./constants";
 

--- a/frontend/src/stores/stateToastList.ts
+++ b/frontend/src/stores/stateToastList.ts
@@ -1,5 +1,5 @@
 import { atom } from "recoil";
-import { ToastMessage } from "./toastType";
+import { ToastMessage } from "../components/Toast/toastType";
 
 export const toastListState = atom<ToastMessage[]>({
   key: "toastListState",


### PR DESCRIPTION
## 작업 개요
- close #249 

## 작업 사항
- [x] 클립보드 공유 텍스트 method로 분리
- [x] 공유 base url 링크 env 추가
- [x] toast recoil state 분리

## 고민한 점들(필수 X)
현재 프로젝트는 `dev`와 `main`으로 `local/dev/production`로 페이즈를 나누어 개발중에 있습니다. 강의 코드를 클립보드에 복사하여 링크를 공유하는 과정에서 `base-url`이 달라야 하기 때문에 이를 위해 `env`로 값을 달리하여 각 페이즈마다의 공유 링크를 가지도록 하였습니다.

추가적으로 state를 한 곳에 모아 관리하기 위해 `Toast`의 recoil state 관련 파일을 `src/stores`로 이동하여 구조 개선 작업을 시작하였습니다. (naming convention에 맞게 이름을 변경하였습니다.)

## 스크린샷(필수 X)
(뷰 변경사항 없음)
