### PR TITLE
Refactor: 강의 조회와 내 프로필 조회 API 분리

### DIFF
--- a/backend/src/lecture/lecture.controller.ts
+++ b/backend/src/lecture/lecture.controller.ts
@@ -123,4 +123,16 @@ export class LectureController {
     const result = await this.lectureService.findLectureRecord(id);
     return res.status(HttpStatus.OK).send(result);
   }
+
+  @UseGuards(CustomAuthGuard)
+  @Get('/list')
+  @ApiHeader({ name: 'Authorization' })
+  async getLectureList(@Req() req: any, @Res() res: Response) {
+    if (!req.user) {
+      throw new HttpException('로그인 되지 않은 사용자입니다.', HttpStatus.UNAUTHORIZED);
+    }
+
+    const result = await this.userService.findLectureList(req.user.email);
+    return res.status(HttpStatus.OK).send(result);
+  }
 }

--- a/backend/src/lecture/lecture.service.ts
+++ b/backend/src/lecture/lecture.service.ts
@@ -91,7 +91,7 @@ export class LectureService {
   }
 
   async findLogs(lecture: Lecture) {
-    return await this.whiteboardLogModel.find({ lecture_id: lecture }).exec();
+    return await this.whiteboardLogModel.find({ lecture_id: lecture }, { _id: 0, lecture_id: 0, __v: 0 }).exec();
   }
 
   async findLectureRecord(id: Types.ObjectId) {

--- a/backend/src/user/dto/userInfo.dto.ts
+++ b/backend/src/user/dto/userInfo.dto.ts
@@ -13,9 +13,8 @@ export class UserInfoDto {
 
   lecture_id: mongoose.Types.ObjectId;
 
-  constructor({ username, email, lecture_id }) {
+  constructor({ username, email }) {
     this.username = username;
     this.email = email;
-    this.lecture_id = lecture_id;
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -19,13 +19,7 @@ export class UserController {
     if (!req.user) {
       throw new HttpException('로그인 되지 않은 사용자입니다.', HttpStatus.UNAUTHORIZED);
     }
-    const userInfo = await (
-      await this.userService.findOneByEmail(req.user.email)
-    ).populate({
-      path: 'lecture_id',
-      select: '-_id title description',
-      populate: { path: 'presenter_id', select: '-_id username' }
-    });
+    const userInfo = await this.userService.findOneByEmail(req.user.email);
 
     if (!userInfo) {
       throw new HttpException('사용자 정보가 존재하지 않습니다.', HttpStatus.NOT_FOUND);

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -28,4 +28,16 @@ export class UserService {
       { new: true }
     );
   }
+
+  async findLectureList(email: string) {
+    return (
+      await (
+        await this.findOneByEmail(email)
+      ).populate({
+        path: 'lecture_id',
+        select: '-__v',
+        populate: { path: 'presenter_id', select: '-_id username' }
+      })
+    ).lecture_id;
+  }
 }


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
강의 조회와 내 프로필 조회 API 분리

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

기존에 내 프로필 조회에서 username, email과 함께 수강한 강의 내역도 같이 응답해줬는데 이 두가지를 분리했으면 좋겠다는 프론트엔드 팀원분들의 의견에 따라 수정하였습니다.
강의 다시보기 정보 조회할 때 강의 id 값이 필요해 이 부분을 포함해서 응답하도록 수정했습니다.
