### PR TITLE
Refactor: 강의생성 API 로그인 된 사용자만 호출하도록 수정

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,7 +1,6 @@
-import { Body, Controller, Get, HttpException, HttpStatus, Post, Req, Res, UseGuards } from '@nestjs/common';
-import { ApiBody, ApiHeader, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, HttpException, HttpStatus, Post, Res } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
-import { CustomAuthGuard } from './auth.guard';
 import { AuthService } from './auth.service';
 import { ResponseSignInDto } from './dto/response-signin.dto';
 import { SignInDto } from './dto/sign-in.dto';
@@ -13,6 +12,7 @@ export class AuthController {
   constructor(private authService: AuthService) {}
 
   @Post('/signup')
+  @ApiOperation({ summary: '회원가입 API' })
   @ApiBody({ type: SignUpDto })
   @ApiResponse({ status: 201 })
   @ApiResponse({ status: 409, description: '이미 가입되어 있는 사용자입니다.' })
@@ -25,6 +25,7 @@ export class AuthController {
   }
 
   @Post('/signin')
+  @ApiOperation({ summary: '로그인 API' })
   @ApiBody({ type: SignInDto })
   @ApiResponse({ status: 200, type: ResponseSignInDto })
   @ApiResponse({ status: 404, description: '해당 사용자가 없습니다.' })
@@ -35,12 +36,5 @@ export class AuthController {
     }
     const result = await this.authService.signIn(signInDto);
     return res.status(HttpStatus.OK).send(new ResponseSignInDto(result));
-  }
-
-  @ApiHeader({ name: 'Authorization' })
-  @UseGuards(CustomAuthGuard)
-  @Get('profile')
-  getProfile(@Req() req: any) {
-    return req.user;
   }
 }

--- a/backend/src/lecture/dto/create-lecture.dto.ts
+++ b/backend/src/lecture/dto/create-lecture.dto.ts
@@ -6,7 +6,4 @@ export class CreateLectureDto {
 
   @ApiProperty({ example: '이런이런 강의입니다' })
   description: string;
-
-  @ApiProperty({ description: '강의를 만든 발표자 email', example: 'example@gmail.com' })
-  email: string;
 }

--- a/backend/src/lecture/lecture.controller.ts
+++ b/backend/src/lecture/lecture.controller.ts
@@ -32,12 +32,18 @@ export class LectureController {
     private readonly userService: UserService
   ) {}
 
+  @UseGuards(CustomAuthGuard)
   @Post()
+  @ApiHeader({ name: 'Authorization' })
   @ApiOperation({ description: '강의를 생성합니다.' })
   @ApiBody({ type: CreateLectureDto })
   @ApiResponse({ status: 201 })
-  async create(@Body() createLecture: CreateLectureDto, @Res() res: Response) {
-    const user = await this.userService.findOneByEmail(createLecture.email);
+  @ApiResponse({ status: 401, description: '로그인 되지 않은 사용자입니다.' })
+  async create(@Body() createLecture: CreateLectureDto, @Req() req: any, @Res() res: Response) {
+    if (!req.user) {
+      throw new HttpException('로그인 되지 않은 사용자입니다.', HttpStatus.UNAUTHORIZED);
+    }
+    const user = await this.userService.findOneByEmail(req.user.email);
     const code = await this.lectureService.createLecture(createLecture, user.id);
     res.status(HttpStatus.CREATED).send({ code: code });
   }

--- a/backend/src/lecture/lecture.controller.ts
+++ b/backend/src/lecture/lecture.controller.ts
@@ -12,7 +12,7 @@ import {
   Res,
   UseGuards
 } from '@nestjs/common';
-import { ApiBody, ApiHeader, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiHeader, ApiOperation, ApiParam, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 import { UserService } from 'src/user/user.service';
 import { CreateLectureDto } from './dto/create-lecture.dto';
@@ -33,6 +33,7 @@ export class LectureController {
   ) {}
 
   @Post()
+  @ApiOperation({ description: '강의를 생성합니다.' })
   @ApiBody({ type: CreateLectureDto })
   @ApiResponse({ status: 201 })
   async create(@Body() createLecture: CreateLectureDto, @Res() res: Response) {
@@ -54,7 +55,8 @@ export class LectureController {
   @ApiHeader({ name: 'Authorization' })
   @ApiParam({ name: 'code', type: 'string' })
   @ApiResponse({ status: 200 })
-  @ApiResponse({ status: 404 })
+  @ApiResponse({ status: 401, description: '로그인 되지 않은 사용자입니다.' })
+  @ApiResponse({ status: 404, description: '유효하지 않은 강의 참여코드입니다.' })
   async enter(@Param('code') code: string, @Req() req: any, @Res() res: Response) {
     if (!req.user) {
       throw new HttpException('로그인 되지 않은 사용자입니다.', HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
Refactor: 강의생성 API 로그인 된 사용자만 호출하도록 수정

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
강의생성하는 API를 기존에는 모든 사용자가 호출할 수 있었고 request body에 강의를 생성하려는 사용자 email이 담겨서 요청이 왔었는데 이 부분을 로그인한 사용자만 호출할 수 있도록 수정했습니다.
API 문서를 위한 swagger 설정들을 추가해줬습니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
swagger 설정들을 추가하면서 코드가 깔끔하지 못해지는거 같아서 이 부분을 추후에 개선해봐야겠다.
