### PR TITLE
Feat(#271): 질문 id와 solved 요청을 받으면, 해당 질문에 ACK 요청을 보낸다.

### DIFF
--- a/mediaServer/src/RelayServer.ts
+++ b/mediaServer/src/RelayServer.ts
@@ -222,6 +222,14 @@ export class RelayServer {
         .emit('asked', new Message(data.type, question.content), { questionId: question.streamKey });
     });
 
+    socket.on('solved', async (data) => {
+      if (clientInfo.type !== ClientType.PRESENTER || clientInfo.roomId !== data.roomId) {
+        console.log('해당 강의실 발표자만 질문을 완료할 수 있습니다.');
+        return;
+      }
+      await updateQuestionStatus(data.roomId, data.questionId);
+    });
+
     socket.on('response', (data) => {
       if (data.type === 'question') {
         updateQuestionStatus(data.roomId, data.questionId);


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
close #271 발표자에게 질문 해결 응답을 받으면, 해당 질문을 완료 처리한다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
redis streams의 consumer group을 사용해서, 질문이 해결되면 pending list에 존재하는 해당 질문을 ACK 요청해서, 추후 발표자 재 접속 시 해결된 질문을 제외하고 재전송 할 수 있도록 설정한다.
 
[#253](https://github.com/boostcampwm2023/web13_Boarlog/pull/253) PR에서 구현했던 updateQuestionStatus() 함수를 사용하여 진행했습니다. 

## 고민한 점들
```
/** 
* event: solved
*/

{
	"type": "question",
	"roomId": ${roomId},
	"questionId": ${questionId}
}
```
발표자가 질문 해결하면, 클라이언트에게 위와 같은 형태로 메시지를 받도록 구성했습니다.