### PR TITLE
Fix: 프로그래스 바 마우스 다운 이벤트 발생 시 사라지는 버그 해결

### DIFF
--- a/frontend/src/pages/Review/components/ProgressBar.tsx
+++ b/frontend/src/pages/Review/components/ProgressBar.tsx
@@ -53,7 +53,6 @@ const ProgressBar = ({
     let percent = (mouseClickedX - left) / width;
     if (percent <= 0) percent = 0;
     updateProgressMsTime(Math.round(totalTime * percent));
-    console.log(Math.round(totalTime * percent));
   };
 
   const handleProgressBarDrag = (event: React.MouseEvent) => {
@@ -80,7 +79,6 @@ const ProgressBar = ({
         setThrottle(true);
         setTimeout(() => {
           handleProgressBarDrag(event);
-
           setThrottle(false);
         }, 250);
       }
@@ -137,7 +135,7 @@ const ProgressBar = ({
         <div className="relative grow h-[6px] bg-grayscale-lightgray">
           <div
             className={`absolute top-0 left-0 h-[6px] w-[0%] bg-boarlog-100`}
-            style={{ width: isProgressBarDrag ? "" : `${getPercentOfProgress(progressMsTime, totalTime)}` }}
+            style={{ width: `${getPercentOfProgress(progressMsTime, totalTime)}` }}
             ref={progressInnerBar}
           ></div>
         </div>


### PR DESCRIPTION
## 작업 개요
프로그래스 바 마우스 다운 이벤트 발생 시 사라지는 버그 해결

## 작업 사항
원인: 드래그 기능 구현 초기에 프로그래스 바의 너비 조절이 딜레이가 생겨 그 문제를 해결하는 과정에서 남아있던 레거시 코드에 의해 버그가 발생했습니다. 

## 고민한 점들(필수 X)


## 스크린샷(필수 X)

