### PR TITLE
Fix(#302): 미디어 서버 메모리 누수 해결

### DIFF
--- a/mediaServer/src/listeners/client.listener.ts
+++ b/mediaServer/src/listeners/client.listener.ts
@@ -5,10 +5,10 @@ import { findRoomInfoById } from '../repositories/room.repository';
 import { ClientConnectionInfo } from '../models/ClientConnectionInfo';
 import { relayServer } from '../main';
 import { getEmailByJwtPayload } from '../utils/auth';
-import { isNotEqualPresenterEmail } from '../validation/client.validation';
+import { isNotEqualPresenterEmail, isReconnectPresenter } from '../validation/client.validation';
 import { RTCPeerConnection } from 'wrtc';
 import { pc_config } from '../config/pc.config';
-import { isReconnectPresenter, sendPrevLectureData, setPresenterConnection } from '../services/presenter.service';
+import { sendPrevLectureData, setPresenterConnection } from '../services/presenter.service';
 import { setParticipantWebRTCConnection, setPresenterWebRTCConnection } from '../services/webrtc-connection.service';
 import { hasCurrentBoardDataInLecture } from '../validation/lecture.validation';
 

--- a/mediaServer/src/listeners/lecture.listener.ts
+++ b/mediaServer/src/listeners/lecture.listener.ts
@@ -1,27 +1,27 @@
 import { Socket } from 'socket.io';
-import { askQuestion, enterAsGuest, getClientEmail, leaveRoom } from '../services/participant.service';
+import { askQuestion, getClientEmail, leaveRoom } from '../services/participant.service';
 import { findClientInfoByEmail } from '../repositories/client.repsitory';
 import { findRoomInfoById } from '../repositories/room.repository';
 import { editWhiteboard, endLecture } from '../services/presenter.service';
 import { updateQuestionStatus } from '../repositories/question-repository';
 import { relayServer } from '../main';
 import { startLecture } from '../services/lecture.service';
-import { isParticipant, isParticipatingClient, isPresenter } from '../validation/client.validation';
+import { isGuest, isParticipant, isParticipatingClient, isPresenter } from '../validation/client.validation';
 import { ClientConnectionInfo } from '../models/ClientConnectionInfo';
 import { RoomConnectionInfo } from '../models/RoomConnectionInfo';
 import { canEnterLecture } from '../validation/lecture.validation';
 
 export class LectureListener {
   // TODO: 클라이언트는 한 개의 방만 접속할 수 있는지? 만약 그렇다면, 이미 참여 중인 빙이 있을 때 요청 거부하도록 처리해야 함
-  lecture = async (socket: Socket) => {
+  enterLecture = async (socket: Socket) => {
     const email = getClientEmail(socket);
     if (!email) {
-      await enterAsGuest(socket);
+      await this.enterLectureAsGuest(socket);
       return;
     }
     const clientInfo = await findClientInfoByEmail(email);
     const clientConnectionInfo = (await relayServer.clientsConnectionInfo.get(email)) as ClientConnectionInfo;
-    if (!isParticipatingClient(clientInfo, clientConnectionInfo, clientInfo.roomId)) {
+    if (!isParticipatingClient(email, clientInfo, clientInfo.roomId)) {
       return;
     }
     const roomInfo = await findRoomInfoById(clientInfo.roomId);
@@ -69,7 +69,40 @@ export class LectureListener {
       if (isParticipant(clientInfo.type, clientInfo.roomId, data.roomId)) {
         return;
       }
-      leaveRoom(clientInfo.roomId, clientConnectionInfo);
+      leaveRoom(clientInfo.roomId, email);
+    });
+  };
+
+  enterLectureAsGuest = async (socket: Socket) => {
+    const clientId = socket.handshake.auth.accessToken;
+    if (!clientId) {
+      console.log('잘못 된 접근입니다.');
+      return;
+    }
+    const clientInfo = await findClientInfoByEmail(clientId);
+    const roomInfo = await findRoomInfoById(clientInfo.roomId);
+    const roomConnectionInfo = relayServer.roomsConnectionInfo.get(clientInfo.roomId) as RoomConnectionInfo;
+    if (!isParticipatingClient(clientId, clientInfo, clientInfo.roomId)) {
+      return;
+    }
+    if (!canEnterLecture(roomConnectionInfo)) {
+      return;
+    }
+    socket.join(clientInfo.roomId);
+    roomConnectionInfo.participantIdList.add(clientId);
+
+    socket.on('ask', async (data) => {
+      if (!isGuest(clientInfo.type, clientInfo.roomId, data.roomId)) {
+        return;
+      }
+      await askQuestion(roomInfo.presenterEmail, data.roomId, data.content);
+    });
+
+    socket.on('leave', (data) => {
+      if (isParticipant(clientInfo.type, clientInfo.roomId, data.roomId)) {
+        return;
+      }
+      leaveRoom(clientInfo.roomId, clientId);
     });
   };
 }

--- a/mediaServer/src/main.ts
+++ b/mediaServer/src/main.ts
@@ -10,6 +10,6 @@ const lectureListener = new LectureListener();
 
 relayServer.listen('/create-room', 'connection', clientListener.createRoom);
 relayServer.listen('/enter-room', 'connection', clientListener.enterRoom);
-relayServer.listen('/lecture', 'connection', lectureListener.lecture);
+relayServer.listen('/lecture', 'connection', lectureListener.enterLecture);
 
 export { relayServer };

--- a/mediaServer/src/models/RoomConnectionInfo.ts
+++ b/mediaServer/src/models/RoomConnectionInfo.ts
@@ -1,17 +1,17 @@
 import { RTCPeerConnection } from 'wrtc';
 import { Socket } from 'socket.io';
-import { ClientConnectionInfo } from './ClientConnectionInfo';
+import { relayServer } from '../main';
 
 export class RoomConnectionInfo {
   private _presenterSocket: Socket | null;
   private readonly _presenterRTCPC: RTCPeerConnection;
-  private readonly _studentInfoList: Set<ClientConnectionInfo>;
+  private readonly _participantIdList: Set<string>;
   private _stream: MediaStream | null;
 
   constructor(RTCPC: RTCPeerConnection) {
     this._presenterSocket = null;
     this._presenterRTCPC = RTCPC;
-    this._studentInfoList = new Set();
+    this._participantIdList = new Set();
     this._stream = null;
   }
 
@@ -19,8 +19,8 @@ export class RoomConnectionInfo {
     this._presenterSocket = socket;
   }
 
-  get studentInfoList(): Set<ClientConnectionInfo> {
-    return this._studentInfoList;
+  get participantIdList(): Set<string> {
+    return this._participantIdList;
   }
 
   set stream(presenterStream: MediaStream) {
@@ -33,17 +33,24 @@ export class RoomConnectionInfo {
 
   endLecture = (roomId: string) => {
     this._presenterRTCPC.close();
-    this._studentInfoList.forEach((studentInfo: ClientConnectionInfo) => {
-      studentInfo.enterSocket?.leave(roomId);
-      studentInfo.enterSocket?.disconnect();
-      studentInfo.lectureSocket?.leave(roomId);
-      studentInfo.lectureSocket?.disconnect();
-      studentInfo.RTCPC?.close();
+    this._participantIdList.forEach((participantId: string) => {
+      const participantConnectionInfo = relayServer.clientsConnectionInfo.get(participantId);
+      if (participantConnectionInfo) {
+        participantConnectionInfo.enterSocket?.leave(roomId);
+        participantConnectionInfo.enterSocket?.disconnect();
+        participantConnectionInfo.lectureSocket?.leave(roomId);
+        participantConnectionInfo.lectureSocket?.disconnect();
+        participantConnectionInfo.RTCPC?.close();
+        relayServer.clientsConnectionInfo.delete(participantId);
+      }
     });
   };
 
-  exitRoom = (clientInfo: ClientConnectionInfo, roomId: string) => {
-    clientInfo.lectureSocket?.leave(roomId);
-    this._studentInfoList.delete(clientInfo);
+  exitRoom = (participantId: string, roomId: string) => {
+    const participantConnectionInfo = relayServer.clientsConnectionInfo.get(participantId);
+    if (participantConnectionInfo) {
+      participantConnectionInfo.lectureSocket?.leave(roomId);
+      this._participantIdList.delete(participantId);
+    }
   };
 }

--- a/mediaServer/src/services/lecture.service.ts
+++ b/mediaServer/src/services/lecture.service.ts
@@ -17,7 +17,7 @@ const startLecture = (
     socket.join(email);
   }
   if (clientInfo.type === ClientType.STUDENT) {
-    roomConnectionInfo.studentInfoList.add(clientConnectionInfo);
+    roomConnectionInfo.participantIdList.add(email);
     fetch((process.env.SERVER_API_URL + '/lecture/' + clientInfo.roomId) as string, {
       method: 'PATCH',
       headers: { Authorization: socket.handshake.auth.accessToken }

--- a/mediaServer/src/services/participant.service.ts
+++ b/mediaServer/src/services/participant.service.ts
@@ -2,9 +2,6 @@ import { Socket } from 'socket.io';
 import { getEmailByJwtPayload } from '../utils/auth';
 import { relayServer } from '../main';
 import { RTCPeerConnection } from 'wrtc';
-import { ClientConnectionInfo } from '../models/ClientConnectionInfo';
-import { findClientInfoByEmail } from '../repositories/client.repsitory';
-import { findRoomInfoById } from '../repositories/room.repository';
 import { ClientType } from '../constants/client-type.constant';
 import { findQuestion, getStreamKeyAndQuestionFromStream, saveQuestion } from '../repositories/question-repository';
 import { StreamReadRaw } from '../types/redis-stream.type';
@@ -12,9 +9,6 @@ import { AskedRequestDto } from '../dto/asked.request.dto';
 import { Message } from '../models/Message';
 import { MessageType } from '../constants/message-type.constant';
 import { sendDataToClient } from './socket.service';
-import { isGuest, isParticipant, isParticipatingClient } from '../validation/client.validation';
-import { RoomConnectionInfo } from '../models/RoomConnectionInfo';
-import { canEnterLecture } from '../validation/lecture.validation';
 
 const getClientEmail = (socket: Socket) => {
   let clientId = '';
@@ -66,43 +60,10 @@ const askQuestion = async (presenterEmail: string, roomId: string, content: stri
   );
 };
 
-const leaveRoom = (roomId: string, clientConnectionInfo: ClientConnectionInfo) => {
-  relayServer.roomsConnectionInfo.get(roomId)?.exitRoom(clientConnectionInfo, roomId);
+const leaveRoom = (roomId: string, participantId: string) => {
+  relayServer.roomsConnectionInfo.get(roomId)?.exitRoom(participantId, roomId);
+  relayServer.clientsConnectionInfo.delete(participantId);
   sendDataToClient('/lecture', roomId, 'response', new Message(MessageType.LECTURE, 'success'));
 };
 
-const enterAsGuest = async (socket: Socket) => {
-  const clientId = socket.handshake.auth.accessToken;
-  if (!clientId) {
-    console.log('잘못 된 접근입니다.');
-    return;
-  }
-  const clientInfo = await findClientInfoByEmail(clientId);
-  const roomInfo = await findRoomInfoById(clientInfo.roomId);
-  const clientConnectionInfo = (await relayServer.clientsConnectionInfo.get(clientId)) as ClientConnectionInfo;
-  const roomConnectionInfo = relayServer.roomsConnectionInfo.get(clientInfo.roomId) as RoomConnectionInfo;
-  if (!isParticipatingClient(clientInfo, clientConnectionInfo, clientInfo.roomId)) {
-    return;
-  }
-  if (!canEnterLecture(roomConnectionInfo)) {
-    return;
-  }
-  socket.join(clientInfo.roomId);
-  roomConnectionInfo.studentInfoList.add(clientConnectionInfo);
-
-  socket.on('ask', async (data) => {
-    if (!isGuest(clientInfo.type, clientInfo.roomId, data.roomId)) {
-      return;
-    }
-    await askQuestion(roomInfo.presenterEmail, data.roomId, data.content);
-  });
-
-  socket.on('leave', (data) => {
-    if (isParticipant(clientInfo.type, clientInfo.roomId, data.roomId)) {
-      return;
-    }
-    leaveRoom(clientInfo.roomId, clientConnectionInfo);
-  });
-};
-
-export { getClientEmail, getClientIdAndClientType, setPresenterMediaStream, askQuestion, leaveRoom, enterAsGuest };
+export { getClientEmail, getClientIdAndClientType, setPresenterMediaStream, askQuestion, leaveRoom };

--- a/mediaServer/src/services/presenter.service.ts
+++ b/mediaServer/src/services/presenter.service.ts
@@ -18,10 +18,6 @@ import { ClientType } from '../constants/client-type.constant';
 import { RoomInfoDto } from '../dto/room-info.dto';
 import { RTCPeerConnection } from 'wrtc';
 
-const isReconnectPresenter = (presenterEmail: string, email: string) => {
-  return presenterEmail === email;
-};
-
 const setPresenterConnection = async (
   roomId: string,
   email: string,
@@ -67,4 +63,4 @@ const sendPrevLectureData = async (roomId: string, email: string, roomInfo: Reco
   });
 };
 
-export { isReconnectPresenter, setPresenterConnection, editWhiteboard, endLecture, sendPrevLectureData };
+export { setPresenterConnection, editWhiteboard, endLecture, sendPrevLectureData };

--- a/mediaServer/src/services/webrtc-connection.service.ts
+++ b/mediaServer/src/services/webrtc-connection.service.ts
@@ -1,7 +1,6 @@
 import { RTCIceCandidate, RTCPeerConnection, RTCSessionDescriptionInit } from 'wrtc';
 import { relayServer } from '../main';
 import { Socket } from 'socket.io';
-import { ClientConnectionInfo } from '../models/ClientConnectionInfo';
 import { mediaConverter } from '../utils/media-converter';
 import { ServerAnswerDto } from '../dto/server-answer.dto';
 import { setPresenterMediaStream } from './participant.service';
@@ -12,10 +11,13 @@ const setTrackEvent = (RTCPC: RTCPeerConnection, roomId: string) => {
     const roomInfo = relayServer.roomsConnectionInfo.get(roomId);
     if (roomInfo) {
       roomInfo.stream = event.streams[0];
-      roomInfo.studentInfoList.forEach((clientConnectionInfo: ClientConnectionInfo) => {
-        event.streams[0].getTracks().forEach(async (track: MediaStreamTrack) => {
-          await clientConnectionInfo.RTCPC.getSenders()[0].replaceTrack(track);
-        });
+      roomInfo.participantIdList.forEach((participantId: string) => {
+        const participantConnectionInfo = relayServer.clientsConnectionInfo.get(participantId);
+        if (participantConnectionInfo) {
+          event.streams[0].getTracks().forEach(async (track: MediaStreamTrack) => {
+            await participantConnectionInfo.RTCPC.getSenders()[0].replaceTrack(track);
+          });
+        }
       });
       mediaConverter.setSink(event.streams[0], roomId);
     }

--- a/mediaServer/src/validation/client.validation.ts
+++ b/mediaServer/src/validation/client.validation.ts
@@ -1,5 +1,5 @@
 import { ClientType } from '../constants/client-type.constant';
-import { ClientConnectionInfo } from '../models/ClientConnectionInfo';
+import { relayServer } from '../main';
 
 const isPresenter = (clientType: string, clientRoomId: string, roomId: string) => {
   if (clientType === ClientType.PRESENTER && clientRoomId === roomId) {
@@ -8,6 +8,10 @@ const isPresenter = (clientType: string, clientRoomId: string, roomId: string) =
   // TODO: 추후 클라이언트로 에러처리 필요
   console.log('해당 발표자가 존재하지 않습니다.');
   return false;
+};
+
+const isReconnectPresenter = (presenterEmail: string, email: string) => {
+  return presenterEmail === email;
 };
 
 const isParticipant = (clientType: string, clientRoomId: string, roomId: string) => {
@@ -36,11 +40,8 @@ const isNotEqualPresenterEmail = (email: string, roomInfo: Record<string, string
   return false;
 };
 
-const isParticipatingClient = (
-  clientInfo: Record<string, string>,
-  clientConnectionInfo: ClientConnectionInfo | undefined,
-  roomId: string
-) => {
+const isParticipatingClient = (clientId: string, clientInfo: Record<string, string>, roomId: string) => {
+  const clientConnectionInfo = relayServer.clientsConnectionInfo.get(clientId);
   if (clientInfo && clientConnectionInfo && roomId) {
     return true;
   }
@@ -49,4 +50,4 @@ const isParticipatingClient = (
   return false;
 };
 
-export { isPresenter, isParticipant, isGuest, isNotEqualPresenterEmail, isParticipatingClient };
+export { isPresenter, isReconnectPresenter, isParticipant, isGuest, isNotEqualPresenterEmail, isParticipatingClient };


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
[미디어 서버 메모리 누수 원인 탐색 과정](https://boarlog.notion.site/939c0576a3394a049b2c1bdd29bbd51f?pvs=4)

미디어 서버 메모리 프로파일링을 바탕으로, 메모리 누수 원인 3가지를 파악했습니다.
- 강의 종료 시 각 클라이언트의 `ClientConnectionInfo`가 적절하게 제거되지 않는다.
- 발표자가 강의 종료를 하지 않고 브라우저만 종료 시, 서버에서 임의로 종료시키는 로직이 존재하지 않는다.
- 발표자가 재접속한 강의 종료 시 사용된 대부분의 메모리가 해제되지 않는다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
1.  강의 종료 시 해당 강의 참여자들의 ClientConnectionInfo 객체를 제거한다.
2. 예정
3. 예정
4. 예정

