### PR TITLE
Fix(#320): Mongoose Schema 속성 타입 Uint8Array 지원 안 하는 문제 해결

### DIFF
--- a/backend/src/lecture/dto/response/response-lecture-record.dto.ts
+++ b/backend/src/lecture/dto/response/response-lecture-record.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { WhiteboardEventDto } from '../whiteboard-event.dto';
 import { Subtitle } from '../../interfaces/Subtitle';
+import { WhiteboardLog } from 'src/lecture/schema/whiteboard-log.schema';
 
 export class LectureRecordDto {
   @ApiProperty()
@@ -12,8 +13,8 @@ export class LectureRecordDto {
   @ApiProperty()
   audio_file: string;
 
-  constructor(logs: WhiteboardEventDto[], subtitles: [Subtitle], audio_file: string) {
-    this.logs = logs;
+  constructor(logs: WhiteboardLog[], subtitles: [Subtitle], audio_file: string) {
+    this.logs = logs.map((log) => new WhiteboardEventDto(log));
     this.subtitles = subtitles;
     this.audio_file = audio_file;
   }

--- a/backend/src/lecture/dto/whiteboard-event.dto.ts
+++ b/backend/src/lecture/dto/whiteboard-event.dto.ts
@@ -10,12 +10,4 @@ export class WhiteboardEventDto {
   width: number;
 
   height: number;
-
-  constructor(log: WhiteboardLog) {
-    this.objects = new Uint8Array(log.objects);
-    this.viewport = log.viewport;
-    this.eventTime = log.eventTime;
-    this.width = log.width;
-    this.height = log.height;
-  }
 }

--- a/backend/src/lecture/dto/whiteboard-event.dto.ts
+++ b/backend/src/lecture/dto/whiteboard-event.dto.ts
@@ -10,4 +10,14 @@ export class WhiteboardEventDto {
   width: number;
 
   height: number;
+
+  constructor(log?: WhiteboardLog) {
+    if (log) {
+      this.objects = new Uint8Array(log.objects);
+      this.viewport = log.viewport;
+      this.eventTime = log.eventTime;
+      this.width = log.width;
+      this.height = log.height;
+    }
+  }
 }

--- a/backend/src/lecture/dto/whiteboard-event.dto.ts
+++ b/backend/src/lecture/dto/whiteboard-event.dto.ts
@@ -1,3 +1,5 @@
+import { WhiteboardLog } from "../schema/whiteboard-log.schema";
+
 export class WhiteboardEventDto {
   objects: Uint8Array;
 
@@ -8,4 +10,12 @@ export class WhiteboardEventDto {
   width: number;
 
   height: number;
+
+  constructor(log: WhiteboardLog) {
+    this.objects = new Uint8Array(log.objects);
+    this.viewport = log.viewport;
+    this.eventTime = log.eventTime;
+    this.width = log.width;
+    this.height = log.height;
+  }
 }

--- a/backend/src/lecture/lecture.controller.ts
+++ b/backend/src/lecture/lecture.controller.ts
@@ -107,7 +107,7 @@ export class LectureController {
     if (!enterCodeDocument) {
       throw new HttpException('해당 강의가 없습니다.', HttpStatus.NOT_FOUND);
     }
-
+    
     await this.lectureService.saveWhiteBoardLog(enterCodeDocument.lecture_id, whiteboardEventDto);
     res.status(HttpStatus.CREATED).send();
   }

--- a/backend/src/lecture/lecture.module.ts
+++ b/backend/src/lecture/lecture.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { User, UserSchema } from 'src/user/user.schema';
 import { UserService } from 'src/user/user.service';
-import { LectureSubtitle, LectureSubtitleSchema } from './lecture-subtitle.schema';
+import { LectureSubtitle, LectureSubtitleSchema } from './schema/lecture-subtitle.schema';
 import { LectureController } from './lecture.controller';
 import { Lecture, LectureSchema } from './schema/lecture.schema';
 import { LectureService } from './lecture.service';

--- a/backend/src/lecture/lecture.service.ts
+++ b/backend/src/lecture/lecture.service.ts
@@ -5,7 +5,7 @@ import { CreateLectureDto } from './dto/create-lecture.dto';
 import { UpdateLectureDto } from './dto/update-lecture.dto';
 import { WhiteboardLog } from './schema/whiteboard-log.schema';
 import { WhiteboardEventDto } from './dto/whiteboard-event.dto';
-import { LectureSubtitle } from './lecture-subtitle.schema';
+import { LectureSubtitle } from './schema/lecture-subtitle.schema';
 import { Lecture } from './schema/lecture.schema';
 import { EnterCode } from './schema/lecture-code.schema';
 import { generateRandomNumber } from 'src/utils/GenerateUtils';

--- a/backend/src/lecture/lecture.service.ts
+++ b/backend/src/lecture/lecture.service.ts
@@ -102,7 +102,7 @@ export class LectureService {
   async findLectureRecord(id: Types.ObjectId) {
     const lecture = await this.lectureModel.findById(id).exec();
     const logs = await this.findLogs(lecture);
-    const subtitles = (await this.lectureSubtitleModel.findOne({ lecture_id: lecture }).exec()).subtitle;
+    const subtitles = (await this.lectureSubtitleModel.findOne({ lecture_id: lecture }).exec())?.subtitle;
     const audioFile = lecture.audio_file;
     return new LectureRecordDto(logs, subtitles, audioFile);
   }

--- a/backend/src/lecture/lecture.service.ts
+++ b/backend/src/lecture/lecture.service.ts
@@ -71,7 +71,7 @@ export class LectureService {
 
   async saveWhiteBoardLog(lecture: Lecture, whiteboardEventDto: WhiteboardEventDto) {
     const whiteboardLog = new this.whiteboardLogModel({
-      objects: whiteboardEventDto.objects,
+      objects: whiteboardEventDto.objects['data'],
       viewport: whiteboardEventDto.viewport,
       eventTime: whiteboardEventDto.eventTime,
       width: whiteboardEventDto.width,

--- a/backend/src/lecture/schema/lecture-subtitle.schema.ts
+++ b/backend/src/lecture/schema/lecture-subtitle.schema.ts
@@ -1,7 +1,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import mongoose from 'mongoose';
-import { Subtitle } from './interfaces/Subtitle';
-import { Lecture } from './schema/lecture.schema';
+import { Subtitle } from '../interfaces/Subtitle';
+import { Lecture } from './lecture.schema';
 
 @Schema()
 export class LectureSubtitle {

--- a/backend/src/lecture/schema/whiteboard-log.schema.ts
+++ b/backend/src/lecture/schema/whiteboard-log.schema.ts
@@ -7,7 +7,7 @@ export type WhiteBoardLogDocument = HydratedDocument<WhiteboardLog>;
 @Schema()
 export class WhiteboardLog {
   @Prop({ required: true })
-  objects: Uint8Array;
+  objects: number[];
 
   @Prop({ required: true })
   viewport: number[];


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->

close #320 Fix: Mongoose Schema property 타입 Uint8Array로 설정 시 에러

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->

```Javascript
@Schema()
export class WhiteboardLog {
  @Prop({ required: true })
  objects: number[];
```

WhiteboardLog 스키마에서 objects 속성을 `Uint8Array`에서 `number[]` 속성으로 바꿨습니다.

<br>

```Javascript
export class WhiteboardEventDto {
  objects: Uint8Array;

  viewport: number[];

  eventTime: number;

  width: number;

  height: number;

  constructor(log?: WhiteboardLog) {
    if (log) {
      this.objects = new Uint8Array(log.objects);
      this.viewport = log.viewport;
      this.eventTime = log.eventTime;
      this.width = log.width;
      this.height = log.height;
    }
  }
}
```

`WhiteboardEventDto`에서는 DB에서 조회한 `WhiteboardLog`의 objects를 다시 Uint8Array 타입으로 캐스팅하여, 프론트엔드에서 받을 때 원래대로 타입 변화 없이 받을 수 있도록 합니다. 생성자 오버로딩으로 Controller에서 Body로 받을 때와 응답할 때 모두 사용할 수 있도록 했습니다.

<br>

```Javascript
export class LectureRecordDto {
  @ApiProperty()
  logs: WhiteboardEventDto[];

  @ApiProperty()
  subtitles: [Subtitle];

  @ApiProperty()
  audio_file: string;

  constructor(logs: WhiteboardLog[], subtitles: [Subtitle], audio_file: string) {
    this.logs = logs.map((log) => new WhiteboardEventDto(log));
    this.subtitles = subtitles;
    this.audio_file = audio_file;
  }
}
```

강의 다시보기 API에서 사용되는 `LectureRecordDto`에도 적절한 타입 변환을 적용해주어 Uint8Array로 프론트에 응답을 내릴 수 있도록 합니다.

