### PR TITLE
Fix(#314, #321): 화이트보드 편집이 반영되지 않는 이슈

### DIFF
--- a/frontend/src/components/Header/components/HeaderInstructorControls.tsx
+++ b/frontend/src/components/Header/components/HeaderInstructorControls.tsx
@@ -196,18 +196,21 @@ const HeaderInstructorControls = ({ setLectureCode, setLectureTitle }: HeaderIns
         offerToReceiveVideo: false
       });
       saveCanvasData(fabricCanvasRef!, canvasData, startTime);
+      socketRef.current.emit("presenterOffer", {
+        socketId: socketRef.current.id,
+        roomId: roomid,
+        SDP: SDP
+      });
       const reducedCanvasData: object = {
-        //objects: new Uint8Array(), // Uint8Array 형태의 데이터는 서버로 전송시 오류가 나서 일단 보내지 않습니다.
+        objects: canvasData.objects,
         viewport: canvasData.viewport,
         eventTime: canvasData.eventTime,
         width: canvasData.width,
         height: canvasData.height
       };
-      socketRef.current.emit("presenterOffer", {
-        socketId: socketRef.current.id,
+      socketRef.current.emit("whiteboardInit", {
         roomId: roomid,
-        SDP: SDP,
-        whiteboard: reducedCanvasData // TODO: 현재 whiteboard의 objects 데이터를 보내는 경우 서버에 SDP 값이 누락되는 문제를 해결해야 합니다.
+        whiteboardDetails: reducedCanvasData
       });
       pcRef.current.setLocalDescription(SDP);
       getPresenterCandidate();

--- a/frontend/src/utils/fabricCanvasUtil.ts
+++ b/frontend/src/utils/fabricCanvasUtil.ts
@@ -43,12 +43,6 @@ export const loadCanvasData = ({
   currentData: ICanvasData;
   newData: ICanvasData;
 }) => {
-  // 서버에 저장되어있던 currentWhiteboardData 의 newData.objects는 ArrayBuffer가 아닌 Node.js Buffer 형태로 전달되어 와서 변환이 필요함
-  // TODO: 서버에서 ArrayBuffer로 전달되도록 수정 필요
-  if (newData.objects?.byteLength === undefined) {
-    // @ts-ignore : newData.objects가 Uint8Array로 변환되어있지 않은 상태라서 임시로 처리했습니다.
-    newData.objects = new Uint8Array(newData.objects.data);
-  }
   const isCanvasDataChanged = newData.objects?.byteLength !== 0;
   const isViewportChanged = JSON.stringify(currentData.viewport) !== JSON.stringify(newData.viewport);
   const isSizeChanged = currentData.width !== newData.width || currentData.height !== newData.height;

--- a/mediaServer/src/constants/client-status.constant.ts
+++ b/mediaServer/src/constants/client-status.constant.ts
@@ -1,0 +1,4 @@
+export enum ClientStatus {
+  ONLINE,
+  OFFLINE
+}

--- a/mediaServer/src/dto/room-info-request.dto.ts
+++ b/mediaServer/src/dto/room-info-request.dto.ts
@@ -1,6 +1,6 @@
 import { ICanvasData } from '../types/canvas-data.interface';
 
-export class RoomInfoDto {
+export class RoomInfoRequestDto {
   presenterEmail: string;
   startTime: Date;
   currentWhiteboardData: string;

--- a/mediaServer/src/dto/room-info-response.dto.ts
+++ b/mediaServer/src/dto/room-info-response.dto.ts
@@ -1,0 +1,25 @@
+import { convertBoardObjectToBuffer } from '../services/lecture.service';
+
+export class RoomInfoResponseDto {
+  private readonly _presenterEmail: string;
+  private readonly _startTime: string;
+  private readonly _currentWhiteboardData: Record<string, string | Buffer>;
+
+  constructor({ presenterEmail, startTime, currentWhiteboardData }: Record<string, string>) {
+    this._presenterEmail = presenterEmail;
+    this._startTime = startTime;
+    this._currentWhiteboardData = convertBoardObjectToBuffer(currentWhiteboardData);
+  }
+
+  get presenterEmail() {
+    return this._presenterEmail;
+  }
+
+  get startTime() {
+    return this._startTime;
+  }
+
+  get currentWhiteboardData() {
+    return this._currentWhiteboardData;
+  }
+}

--- a/mediaServer/src/dto/server-answer.dto.ts
+++ b/mediaServer/src/dto/server-answer.dto.ts
@@ -1,11 +1,13 @@
+import { RoomInfoResponseDto } from './room-info-response.dto';
+
 export class ServerAnswerDto {
-  whiteboard: Record<string, string>;
+  whiteboard: Record<string, string | Buffer>;
   startTime: string;
   SDP: RTCSessionDescriptionInit;
 
-  constructor(whiteboard: Record<string, string>, startTime: string, SDP: RTCSessionDescriptionInit) {
-    this.whiteboard = whiteboard;
-    this.startTime = startTime;
+  constructor(roomInfo: RoomInfoResponseDto, SDP: RTCSessionDescriptionInit) {
+    this.whiteboard = roomInfo.currentWhiteboardData;
+    this.startTime = roomInfo.startTime;
     this.SDP = SDP;
   }
 }

--- a/mediaServer/src/listeners/client.listener.ts
+++ b/mediaServer/src/listeners/client.listener.ts
@@ -10,7 +10,7 @@ import { RTCPeerConnection } from 'wrtc';
 import { pc_config } from '../config/pc.config';
 import { sendPrevLectureData, setPresenterConnection } from '../services/presenter.service';
 import { setParticipantWebRTCConnection, setPresenterWebRTCConnection } from '../services/webrtc-connection.service';
-import { hasCurrentBoardDataInLecture } from '../validation/lecture.validation';
+import { canEnterRoom } from '../validation/lecture.validation';
 
 export class ClientListener {
   createRoom = (socket: Socket) => {
@@ -47,7 +47,7 @@ export class ClientListener {
         await saveClientInfo(clientId, clientType, data.roomId);
         relayServer.clientConnectionInfoList.set(clientId, new ClientConnectionInfo(RTCPC, socket));
         const roomInfo = await findRoomInfoById(data.roomId);
-        if (!hasCurrentBoardDataInLecture(roomInfo.currentWhiteboardData)) {
+        if (!canEnterRoom(roomInfo)) {
           return;
         }
         await setParticipantWebRTCConnection(data.roomId, clientId, RTCPC, roomInfo, socket, data.SDP);

--- a/mediaServer/src/listeners/lecture.listener.ts
+++ b/mediaServer/src/listeners/lecture.listener.ts
@@ -82,6 +82,7 @@ export class LectureListener {
           return;
         }
         presenterStreamInfo.pauseRecording();
+        clientConnectionInfo.setOfflineStatus();
         clientConnectionInfo.disconnectWebRTCConnection();
       }
       if (isParticipant(clientInfo.type, clientInfo.roomId, clientInfo.roomId)) {

--- a/mediaServer/src/main.ts
+++ b/mediaServer/src/main.ts
@@ -2,7 +2,7 @@ import { RelayServer } from './RelayServer';
 import { ClientListener } from './listeners/client.listener';
 import { LectureListener } from './listeners/lecture.listener';
 
-const PORT = 3000;
+const PORT = 3001;
 
 const relayServer = new RelayServer(PORT);
 const clientListener = new ClientListener();

--- a/mediaServer/src/models/ClientConnectionInfo.ts
+++ b/mediaServer/src/models/ClientConnectionInfo.ts
@@ -1,15 +1,18 @@
 import { RTCPeerConnection } from 'wrtc';
 import { Socket } from 'socket.io';
+import { ClientStatus } from '../constants/client-status.constant';
 
 export class ClientConnectionInfo {
   private readonly _RTCPC: RTCPeerConnection;
   private _enterSocket: Socket | null;
   private _lectureSocket: Socket | null;
+  private _status: ClientStatus;
 
   constructor(RTCPC: RTCPeerConnection, enterSocket?: Socket) {
     this._RTCPC = RTCPC;
     this._enterSocket = enterSocket ?? null;
     this._lectureSocket = null;
+    this._status = ClientStatus.ONLINE;
   }
 
   get RTCPC(): RTCPeerConnection {
@@ -29,5 +32,9 @@ export class ClientConnectionInfo {
     this._enterSocket?.disconnect();
     this._lectureSocket?.leave(roomId);
     this._lectureSocket?.disconnect();
+  };
+
+  setOfflineStatus = () => {
+    this._status = ClientStatus.OFFLINE;
   };
 }

--- a/mediaServer/src/models/ClientConnectionInfo.ts
+++ b/mediaServer/src/models/ClientConnectionInfo.ts
@@ -3,7 +3,7 @@ import { Socket } from 'socket.io';
 import { ClientStatus } from '../constants/client-status.constant';
 
 export class ClientConnectionInfo {
-  private readonly _RTCPC: RTCPeerConnection;
+  private _RTCPC: RTCPeerConnection;
   private _enterSocket: Socket | null;
   private _lectureSocket: Socket | null;
   private _status: ClientStatus;
@@ -19,9 +19,18 @@ export class ClientConnectionInfo {
     return this._RTCPC;
   }
 
+  get status() {
+    return this._status;
+  }
+
   set lectureSocket(socket: Socket) {
     this._lectureSocket = socket;
   }
+
+  updateConnection = (RTCPC: RTCPeerConnection, socket: Socket) => {
+    this._RTCPC = RTCPC;
+    this._enterSocket = socket;
+  };
 
   disconnectWebRTCConnection = () => {
     this._RTCPC.close();
@@ -36,5 +45,9 @@ export class ClientConnectionInfo {
 
   setOfflineStatus = () => {
     this._status = ClientStatus.OFFLINE;
+  };
+
+  setOnlineStatus = () => {
+    this._status = ClientStatus.ONLINE;
   };
 }

--- a/mediaServer/src/repositories/room.repository.ts
+++ b/mediaServer/src/repositories/room.repository.ts
@@ -1,13 +1,14 @@
-import { RoomInfoDto } from '../dto/room-info.dto';
+import { RoomInfoRequestDto } from '../dto/room-info-request.dto';
 import { redis } from '../config/redis.config';
 import { ROOM_INFO_KEY_PREFIX } from '../constants/redis-key.constant';
 import { ICanvasData } from '../types/canvas-data.interface';
+import { RoomInfoResponseDto } from '../dto/room-info-response.dto';
 
-const findRoomInfoById = (roomId: string) => {
-  return redis.hgetall(ROOM_INFO_KEY_PREFIX + roomId);
+const findRoomInfoById = async (roomId: string) => {
+  return new RoomInfoResponseDto(await redis.hgetall(ROOM_INFO_KEY_PREFIX + roomId));
 };
 
-const saveRoomInfo = async (roomId: string, roomInfo: RoomInfoDto) => {
+const saveRoomInfo = async (roomId: string, roomInfo: RoomInfoRequestDto) => {
   await redis.hset(ROOM_INFO_KEY_PREFIX + roomId, roomInfo);
 };
 

--- a/mediaServer/src/services/lecture.service.ts
+++ b/mediaServer/src/services/lecture.service.ts
@@ -41,4 +41,17 @@ const scheduleEndLecture = (roomId: string, presenterId: string) => {
   relayServer.scheduledEndLectureList.set(roomId, timerId);
 };
 
-export { startLecture, scheduleEndLecture };
+const convertBoardObjectToBuffer = (currentBoardDetails: string | undefined) => {
+  if (!currentBoardDetails) {
+    return currentBoardDetails;
+  }
+  const boardDetails = JSON.parse(currentBoardDetails);
+  if (!boardDetails.objects) {
+    boardDetails.objects = Buffer.alloc(0);
+  } else {
+    boardDetails.objects = Buffer.from(boardDetails.objects);
+  }
+  return boardDetails;
+};
+
+export { startLecture, scheduleEndLecture, convertBoardObjectToBuffer };

--- a/mediaServer/src/services/socket.service.ts
+++ b/mediaServer/src/services/socket.service.ts
@@ -1,7 +1,21 @@
 import { relayServer } from '../main';
+import { StreamReadRaw } from '../types/redis-stream.type';
+import { RoomInfoResponseDto } from '../dto/room-info-response.dto';
 
 const sendDataToClient = (namespace: string, target: string, eventName: string, data: any) => {
   relayServer.socket.of(namespace).to(target).emit(eventName, data);
 };
 
-export { sendDataToClient };
+const sendRoomDetailsToReconnectedPresenter = (
+  email: string,
+  roomInfo: RoomInfoResponseDto,
+  unsolvedQuestions: StreamReadRaw
+) => {
+  sendDataToClient('/create-room', email, 'reconnectPresenter', {
+    whiteboard: roomInfo.currentWhiteboardData,
+    startTime: roomInfo.startTime,
+    questions: unsolvedQuestions[0][1]
+  });
+};
+
+export { sendDataToClient, sendRoomDetailsToReconnectedPresenter };

--- a/mediaServer/src/services/webrtc-connection.service.ts
+++ b/mediaServer/src/services/webrtc-connection.service.ts
@@ -6,6 +6,7 @@ import { ServerAnswerDto } from '../dto/server-answer.dto';
 import { setPresenterMediaStream } from './participant.service';
 import { sendDataToClient } from './socket.service';
 import { RoomConnectionInfo } from '../models/RoomConnectionInfo';
+import { RoomInfoResponseDto } from '../dto/room-info-response.dto';
 
 const setTrackEvent = (RTCPC: RTCPeerConnection, roomId: string) => {
   RTCPC.ontrack = (event) => {
@@ -63,7 +64,7 @@ const setParticipantWebRTCConnection = async (
   roomId: string,
   clientId: string,
   RTCPC: RTCPeerConnection,
-  roomInfo: Record<string, string>,
+  roomInfo: RoomInfoResponseDto,
   socket: Socket,
   offer: RTCSessionDescriptionInit
 ) => {
@@ -71,7 +72,7 @@ const setParticipantWebRTCConnection = async (
   exchangeCandidate('/enter-room', clientId, socket);
   RTCPC.setRemoteDescription(offer);
   const answer = await RTCPC.createAnswer();
-  const answerData = new ServerAnswerDto(JSON.parse(roomInfo.currentWhiteboardData), roomInfo.startTime, answer);
+  const answerData = new ServerAnswerDto(roomInfo, answer);
   sendDataToClient('/enter-room', clientId, 'serverAnswer', answerData);
   RTCPC.setLocalDescription(answer);
 };

--- a/mediaServer/src/validation/client.validation.ts
+++ b/mediaServer/src/validation/client.validation.ts
@@ -1,5 +1,6 @@
 import { ClientType } from '../constants/client-type.constant';
 import { relayServer } from '../main';
+import { RoomInfoResponseDto } from '../dto/room-info-response.dto';
 
 const isPresenter = (clientType: string, clientRoomId: string, roomId: string) => {
   if (clientType === ClientType.PRESENTER && clientRoomId === roomId) {
@@ -32,8 +33,8 @@ const isGuest = (clientType: string, clientRoomId: string, roomId: string) => {
   return false;
 };
 
-const isNotEqualPresenterEmail = (email: string, roomInfo: Record<string, string>): boolean => {
-  if (Object.keys(roomInfo).length > 0 && roomInfo.presenterEmail !== email) {
+const isNotEqualPresenterEmail = (email: string, roomInfo: RoomInfoResponseDto): boolean => {
+  if (roomInfo.presenterEmail && roomInfo.presenterEmail !== email) {
     console.log('이미 존재하는 강의실입니다.');
     return true;
   }

--- a/mediaServer/src/validation/lecture.validation.ts
+++ b/mediaServer/src/validation/lecture.validation.ts
@@ -1,5 +1,6 @@
 import { RoomConnectionInfo } from '../models/RoomConnectionInfo';
 import { DisconnectReason } from 'socket.io';
+import { RoomInfoResponseDto } from '../dto/room-info-response.dto';
 
 const canEnterLecture = (roomConnectionInfo: RoomConnectionInfo | undefined) => {
   if (roomConnectionInfo) {
@@ -10,8 +11,8 @@ const canEnterLecture = (roomConnectionInfo: RoomConnectionInfo | undefined) => 
   return false;
 };
 
-const hasCurrentBoardDataInLecture = (currentBoardData: string) => {
-  if (currentBoardData) {
+const canEnterRoom = (roomInfo: RoomInfoResponseDto) => {
+  if (roomInfo.presenterEmail) {
     return true;
   }
   console.log('정상적인 접근이 아닙니다');
@@ -22,4 +23,4 @@ const isLectureOngoing = (reason: DisconnectReason) => {
   return reason != 'server namespace disconnect';
 };
 
-export { canEnterLecture, hasCurrentBoardDataInLecture, isLectureOngoing };
+export { canEnterLecture, canEnterRoom, isLectureOngoing };


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feature(#133): canvas 구현~ -->
<!-- "여기에 작성하세요" 는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- #321 

화이트보드 화면 데이터를 담고 있는 ICanvasData의 objects 필드가 string에서 Uint8Array 타입으로 스펙이 변경되면서, Redis에서 현재 화이트보드 데이터를 가져올 때 타입이 맞지 않아 이슈가 발생했습니다.

- #314 

클라이언트에서 WebRTC 연결에 필요한 SDP와 Buffer 타입 데이터를 같이 보낼 때, 미디어 서버에서 SDP를 받아올 수 없는 이슈입니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
1. Redis에서 가져온 현재 화이트보드 데이터가 JSON 문자열로 직렬화되어 있기 때문에, 역직렬화 후 화이트보드 화면 데이터만 Buffer 타입으로 변환해 주고 클라이언트에게 전달하여 해결했습니다.

2. 클라이언트에서 SDP와 Buffer 타입 데이터(화이트보드 화면 데이터)를 각각 보내도록 구성했습니다. 만약 발표자가 재접속한다면 화이트보드 화면이 초기화가 될 수 있기 때문에, 클라이언트별 상태 정보를 저장하여 재접속한 발표자인 경우에는 화이트보드 화면을 초기화 시키지 않도록 했습니다.